### PR TITLE
Fix: Add workaround for AI SDK v4 tool compatibility issue with Claude Sonnet 4

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -36,7 +36,8 @@
       "Bash(npm info:*)",
       "Bash(NODE_OPTIONS=\"--max-old-space-size=4096 --no-warnings\" yarn test)",
       "Bash(gh pr create:*)",
-      "Bash(git restore:*)"
+      "Bash(git restore:*)",
+      "Bash(git cherry-pick:*)"
     ],
     "deny": []
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,3 +93,6 @@ When completing any development task:
 - **Memory leak warnings during tests**: Already mitigated with proper cleanup and --no-warnings flag
 - **"Tests closed successfully but something prevents main process from exiting"**: Expected behavior with vitest worker pools, not an actual issue
 - **WebSocket mock cleanup**: Ensure all WebSocket sessions are properly closed in afterEach hooks
+- **AI SDK v4 tool compatibility with Claude Sonnet 4**: The AI SDK v4 has a known issue where the `tool()` helper generates incorrect schema format for Claude. See https://github.com/vercel/ai/issues/7333
+  - **Workaround**: Set `DISABLE_AI_TOOLS=true` in your environment variables to disable tools temporarily
+  - **Alternative**: Use direct JSON schema format instead of the AI SDK's `tool()` helper

--- a/packages/spike.land/src/anthropicHandler.ts
+++ b/packages/spike.land/src/anthropicHandler.ts
@@ -26,6 +26,21 @@ export async function handleAnthropicRequest(
 
     // Clone request to ensure body stream can be consumed
     const clonedRequest = originalRequest.clone();
+    
+    // Log the request body to debug tool format issues
+    if (clonedRequest.method === "POST") {
+      try {
+        const bodyText = await clonedRequest.clone().text();
+        const bodyJson = JSON.parse(bodyText);
+        if (bodyJson.tools) {
+          console.log("[Anthropic Proxy] Request contains tools:", 
+            JSON.stringify(bodyJson.tools, null, 2)
+          );
+        }
+      } catch (_e) {
+        console.log("[Anthropic Proxy] Could not parse request body");
+      }
+    }
 
     // Set up headers with proper authorization format
     const headers = new Headers(clonedRequest.headers);
@@ -45,8 +60,17 @@ export async function handleAnthropicRequest(
     // Make the fetch request and handle errors
     const response = await fetch(request);
     if (!response.ok) {
+      // Try to get error details from response
+      let errorDetails = "";
+      try {
+        const errorBody = await response.clone().text();
+        errorDetails = ` - ${errorBody}`;
+        console.error("[Anthropic Proxy] API Error Response:", errorBody);
+      } catch (_e) {
+        // Ignore if we can't read the error body
+      }
       throw new Error(
-        `ANTHROPIC API responded with status: ${request.url} ${response.status} `,
+        `ANTHROPIC API responded with status: ${request.url} ${response.status}${errorDetails}`,
       );
     }
 

--- a/packages/spike.land/src/env.ts
+++ b/packages/spike.land/src/env.ts
@@ -18,4 +18,5 @@ export default interface Env {
   LIMITERS: DurableObjectNamespace;
   R2: R2Bucket;
   X9: R2Bucket;
+  DISABLE_AI_TOOLS?: string; // Set to "true" to disable AI tools (workaround for AI SDK v4 issue)
 }

--- a/packages/spike.land/src/handlers/postHandler.ts
+++ b/packages/spike.land/src/handlers/postHandler.ts
@@ -371,13 +371,22 @@ export class PostHandler {
         execute: (args: Record<string, unknown>) => Promise<Record<string, unknown>>;
       }>);
 
+      // Check if we should disable tools due to AI SDK compatibility issues
+      const disableTools = this.env.DISABLE_AI_TOOLS === "true";
+      
+      if (disableTools) {
+        console.warn(
+          `[AI Routes][${requestId}] AI tools are disabled via DISABLE_AI_TOOLS environment variable`,
+        );
+      }
+
       const result = await streamText({
         model: anthropic("claude-4-sonnet-20250514"),
         system: systemPrompt,
         messages,
-        tools: processedTools,
-        toolChoice: "auto",
-        maxSteps: 10,
+        tools: disableTools ? undefined : processedTools,
+        toolChoice: disableTools ? undefined : "auto",
+        maxSteps: disableTools ? undefined : 10,
         onStepFinish: async ({ stepType, toolResults }) => {
           if (stepType === "tool-result" && toolResults) {
             try {


### PR DESCRIPTION
### **User description**
## Summary
Adds a workaround for the AI SDK v4 compatibility issue with Claude Sonnet 4 where tools are sent in an incompatible format.

## Problem
The AI SDK v4 sends tools to Anthropic's API with an incorrect format, causing the error:
```
"tools.0.custom.input_schema.type: Input should be 'object'"
```

This is a known issue tracked at: https://github.com/vercel/ai/issues/7333

## Solution
- Added `DISABLE_AI_TOOLS` environment variable that can be set to "true" to disable tools temporarily
- Added request/response logging in the Anthropic proxy for better debugging
- Documented the issue and workaround in CLAUDE.md

## How to Use
Set the environment variable in your `.dev.vars` or deployment configuration:
```
DISABLE_AI_TOOLS=true
```

This will disable tools until the AI SDK team fixes the compatibility issue.

## Changes
- Added `DISABLE_AI_TOOLS` to the Env interface
- Modified PostHandler to check for the environment variable and conditionally disable tools
- Enhanced error logging in anthropicHandler
- Updated documentation with known issue and workaround

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add workaround for AI SDK v4 tool compatibility issue

- Implement `DISABLE_AI_TOOLS` environment variable to disable tools

- Enhance error logging in Anthropic proxy for debugging

- Document known issue and workaround in CLAUDE.md


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Environment Variable"] --> B["PostHandler Check"]
  B --> C["Conditional Tool Disable"]
  D["Anthropic Proxy"] --> E["Enhanced Logging"]
  F["Documentation"] --> G["Issue Workaround Guide"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>anthropicHandler.ts</strong><dd><code>Enhanced logging for Anthropic API debugging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/spike.land/src/anthropicHandler.ts

<ul><li>Add request body logging for debugging tool format issues<br> <li> Enhance error response logging with detailed error messages<br> <li> Improve error handling with response body parsing</ul>


</details>


  </td>
  <td><a href="https://github.com/zerdos/spike.land/pull/1913/files#diff-bd98a631c060cb7aad39a4d482727c0d7a32d2513a1b027f5d2220c035f68ea6">+25/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>env.ts</strong><dd><code>Add environment variable for tool disabling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/spike.land/src/env.ts

<ul><li>Add <code>DISABLE_AI_TOOLS</code> optional environment variable<br> <li> Include documentation comment explaining the workaround purpose</ul>


</details>


  </td>
  <td><a href="https://github.com/zerdos/spike.land/pull/1913/files#diff-06f8ae1ab85b6a5e4cca9df576e9d6bd85d1517471847a61034fca8af67d09fc">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>settings.local.json</strong><dd><code>Update Claude settings configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.claude/settings.local.json

- Add `git cherry-pick` command to allowed bash commands list


</details>


  </td>
  <td><a href="https://github.com/zerdos/spike.land/pull/1913/files#diff-fca16cae5b0e32edfa6b55eaa32a98ffbf4a0c7d885fb585785fc83b6ea2d9c3">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>postHandler.ts</strong><dd><code>Implement conditional tool disabling logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/spike.land/src/handlers/postHandler.ts

<ul><li>Check <code>DISABLE_AI_TOOLS</code> environment variable before enabling tools<br> <li> Conditionally disable tools, toolChoice, and maxSteps parameters<br> <li> Add warning log when tools are disabled</ul>


</details>


  </td>
  <td><a href="https://github.com/zerdos/spike.land/pull/1913/files#diff-4f39b4e3e99eb3607ec04080a8285be2c3ff8a9848a244049de8fdc0fbbce252">+12/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Document AI SDK compatibility issue workaround</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CLAUDE.md

<ul><li>Document AI SDK v4 tool compatibility issue with Claude Sonnet 4<br> <li> Provide workaround instructions using <code>DISABLE_AI_TOOLS</code> variable<br> <li> Reference GitHub issue for tracking the problem</ul>


</details>


  </td>
  <td><a href="https://github.com/zerdos/spike.land/pull/1913/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

