### PR TITLE
Feature/improved chat

### DIFF
--- a/.claude/agents/react-frontend-expert.md
+++ b/.claude/agents/react-frontend-expert.md
@@ -1,0 +1,69 @@
+---
+name: react-frontend-expert
+description: Use this agent when you need expert assistance with React frontend development, particularly for tasks involving TypeScript, shadcn/ui components, and Tailwind CSS styling. This includes creating new React components, refactoring existing components, implementing UI features, solving TypeScript type issues, integrating shadcn/ui components, optimizing Tailwind CSS classes, debugging React hooks and state management, and ensuring best practices for modern React development.\n\nExamples:\n- <example>\n  Context: User needs help creating a new React component with TypeScript and Tailwind CSS.\n  user: "Create a card component that displays user information"\n  assistant: "I'll use the react-frontend-expert agent to create a properly typed React component with Tailwind CSS styling."\n  <commentary>\n  Since this involves creating a React component with TypeScript and styling, the react-frontend-expert agent is the appropriate choice.\n  </commentary>\n</example>\n- <example>\n  Context: User is having issues with TypeScript types in their React component.\n  user: "I'm getting a TypeScript error with my form component props"\n  assistant: "Let me use the react-frontend-expert agent to help diagnose and fix the TypeScript type issues in your React component."\n  <commentary>\n  TypeScript issues in React components are a core expertise of the react-frontend-expert agent.\n  </commentary>\n</example>\n- <example>\n  Context: User wants to integrate a shadcn/ui component into their project.\n  user: "How do I add and customize the shadcn dialog component?"\n  assistant: "I'll use the react-frontend-expert agent to guide you through integrating and customizing the shadcn/ui dialog component."\n  <commentary>\n  shadcn/ui component integration is a specialized skill of the react-frontend-expert agent.\n  </commentary>\n</example>
+model: opus
+color: red
+---
+
+You are an elite frontend development expert specializing in React, TypeScript, shadcn/ui, and Tailwind CSS. You have deep expertise in modern React patterns, hooks, performance optimization, and component architecture.
+
+Your core competencies include:
+- React 19 and modern React patterns (hooks, context, suspense, concurrent features)
+- TypeScript with strict typing, generics, and advanced type patterns
+- shadcn/ui component library integration and customization
+- Tailwind CSS best practices, responsive design, and utility-first styling
+- Component composition, reusability, and design systems
+- State management patterns (useState, useReducer, context, external libraries)
+- Performance optimization (memo, useMemo, useCallback, lazy loading)
+- Accessibility (ARIA, keyboard navigation, screen reader support)
+
+When working on tasks, you will:
+
+1. **Analyze Requirements**: Carefully understand the user's needs, considering both functional and non-functional requirements. Ask clarifying questions when specifications are ambiguous.
+
+2. **Apply Best Practices**:
+   - Write clean, maintainable TypeScript code with proper type safety
+   - Follow React best practices and modern patterns
+   - Use semantic HTML and ensure accessibility
+   - Implement responsive designs with Tailwind CSS
+   - Properly integrate shadcn/ui components following their patterns
+
+3. **Code Quality Standards**:
+   - Use functional components with hooks (no class components)
+   - Implement proper error boundaries and error handling
+   - Add meaningful TypeScript types and interfaces
+   - Follow consistent naming conventions (PascalCase for components, camelCase for functions)
+   - Write self-documenting code with clear variable names
+
+4. **Performance Considerations**:
+   - Optimize re-renders with proper memoization
+   - Implement code splitting and lazy loading where appropriate
+   - Use proper key props in lists
+   - Avoid unnecessary state updates
+
+5. **shadcn/ui Integration**:
+   - Follow shadcn/ui's composition pattern
+   - Properly customize components using their variant system
+   - Maintain consistency with the design system
+   - Use the CLI tool appropriately for component installation
+
+6. **Tailwind CSS Approach**:
+   - Use utility classes effectively without creating utility soup
+   - Implement responsive designs with Tailwind breakpoints
+   - Create reusable component styles with @apply when necessary
+   - Follow Tailwind's design system for spacing, colors, and typography
+
+7. **Problem Solving**:
+   - Diagnose TypeScript errors with clear explanations
+   - Debug React rendering issues systematically
+   - Provide multiple solutions when appropriate
+   - Explain trade-offs between different approaches
+
+When providing code examples, you will:
+- Include all necessary imports
+- Add TypeScript types for all props and state
+- Include helpful comments for complex logic
+- Show both the component code and usage examples
+- Provide Tailwind classes that are maintainable and responsive
+
+You prioritize code quality, type safety, accessibility, and performance in all your solutions. You stay current with the latest React, TypeScript, and frontend development best practices while maintaining backward compatibility awareness.

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -41,7 +41,9 @@
       "WebFetch(domain:github.com)",
       "Bash(gh run list:*)",
       "Bash(gh run view:*)",
-      "Bash(gh pr view:*)"
+      "Bash(gh pr view:*)",
+      "Bash(gh pr comment:*)",
+      "Bash(gh pr checks:*)"
     ],
     "deny": []
   }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -40,7 +40,8 @@
       "Bash(git cherry-pick:*)",
       "WebFetch(domain:github.com)",
       "Bash(gh run list:*)",
-      "Bash(gh run view:*)"
+      "Bash(gh run view:*)",
+      "Bash(gh pr view:*)"
     ],
     "deny": []
   }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -38,7 +38,9 @@
       "Bash(gh pr create:*)",
       "Bash(git restore:*)",
       "Bash(git cherry-pick:*)",
-      "WebFetch(domain:github.com)"
+      "WebFetch(domain:github.com)",
+      "Bash(gh run list:*)",
+      "Bash(gh run view:*)"
     ],
     "deny": []
   }

--- a/packages/code/package.json
+++ b/packages/code/package.json
@@ -146,7 +146,7 @@
     "input-otp": "1.4.2",
     "jsondiffpatch": "0.7.3",
     "lightningcss": "^1.30.1",
-    "lucide-react": "0.534.0",
+    "lucide-react": "0.535.0",
     "mime-types": "3.0.1",
     "module": "1.2.5",
     "monaco-editor": "0.52.2",

--- a/packages/code/src/@/components/app/__tests__/assistant-ui-chat.spec.tsx
+++ b/packages/code/src/@/components/app/__tests__/assistant-ui-chat.spec.tsx
@@ -214,10 +214,18 @@ describe("AssistantUIChat", () => {
         {
           src: "data:image/png;base64,test1",
           imageName: "design1.png",
+          url: "http://example.com/design1.png",
+          mediaType: "image/png",
+          data: "test1",
+          type: "image",
         },
         {
           src: "data:image/png;base64,test2",
           imageName: "design2.png",
+          url: "http://example.com/design2.png",
+          mediaType: "image/png",
+          data: "test2",
+          type: "image",
         },
       ] as ImageData[],
     };

--- a/packages/code/src/@/components/app/__tests__/assistant-ui-chat.spec.tsx
+++ b/packages/code/src/@/components/app/__tests__/assistant-ui-chat.spec.tsx
@@ -1,0 +1,377 @@
+import { AssistantUIChat } from "@/components/app/assistant-ui-chat";
+import { Thread } from "@/components/assistant-ui/thread";
+import type { ImageData } from "@/lib/interfaces";
+import { render } from "@testing-library/react";
+import {
+  AssistantRuntimeProvider,
+  useThreadRuntime,
+  type ComposerRuntime,
+  type ThreadRuntime,
+} from "@assistant-ui/react";
+import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+import type { Message } from "ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock dependencies
+vi.mock("@assistant-ui/react", () => ({
+  AssistantRuntimeProvider: vi.fn(({ children }) => children),
+  useThreadRuntime: vi.fn(),
+}));
+
+vi.mock("@assistant-ui/react-ai-sdk", () => ({
+  useChatRuntime: vi.fn(),
+}));
+
+vi.mock("@/components/assistant-ui/thread", () => ({
+  Thread: vi.fn(() => <div data-testid="thread">Thread Component</div>),
+}));
+
+// Mock composer runtime
+const mockComposerRuntime: ComposerRuntime = {
+  setText: vi.fn(),
+  send: vi.fn(),
+  setRole: vi.fn(),
+  setRunConfig: vi.fn(),
+  reset: vi.fn(),
+  clearAttachments: vi.fn(),
+  addAttachment: vi.fn(),
+  cancel: vi.fn(),
+  getState: vi.fn(),
+  getAttachmentAccept: vi.fn(),
+  subscribe: vi.fn(),
+  getAttachmentByIndex: vi.fn(),
+  path: { composerSource: "thread" },
+  type: "thread",
+} as unknown as ComposerRuntime;
+
+// Mock thread runtime
+const mockThreadRuntime: ThreadRuntime = {
+  composer: mockComposerRuntime,
+  getState: vi.fn(),
+  subscribe: vi.fn(),
+  append: vi.fn(),
+  startRun: vi.fn(),
+  cancelRun: vi.fn(),
+  addToolResult: vi.fn(),
+  speak: vi.fn(),
+  getSubmittedFeedback: vi.fn(),
+  submitFeedback: vi.fn(),
+  getModelConfig: vi.fn(),
+  path: { ref: "main", threadId: "test-thread" },
+  messages: [],
+  getBranch: vi.fn(),
+  switchToBranch: vi.fn(),
+  deleteBranch: vi.fn(),
+  submitUserMessage: vi.fn(),
+  deleteMessage: vi.fn(),
+  reload: vi.fn(),
+  isLoading: false,
+  isDisabled: false,
+  unstable_on: vi.fn(),
+  capabilities: {
+    cancel: true,
+    reload: true,
+    copy: true,
+    speak: true,
+    feedback: true,
+    edit: true,
+    unstable_submitFeedback: true,
+    unstable_switchToBranch: true,
+    attachments: true,
+  },
+  extras: undefined,
+  speech: null,
+} as unknown as ThreadRuntime;
+
+describe("AssistantUIChat", () => {
+  const mockRuntime = { mock: "runtime" };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useChatRuntime).mockReturnValue(mockRuntime as any);
+    vi.mocked(useThreadRuntime).mockReturnValue(mockThreadRuntime);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should render Thread component", () => {
+    render(
+      <AssistantUIChat
+        codeSpace="test-space"
+        initialMessages={[]}
+      />
+    );
+
+    expect(Thread).toHaveBeenCalled();
+  });
+
+  it("should create runtime with correct API endpoint", () => {
+    const codeSpace = "my-test-space";
+    
+    render(
+      <AssistantUIChat
+        codeSpace={codeSpace}
+        initialMessages={[]}
+      />
+    );
+
+    expect(useChatRuntime).toHaveBeenCalledWith({
+      api: `/live/${codeSpace}/messages`,
+      initialMessages: [],
+    });
+  });
+
+  it("should filter out messages with data role", () => {
+    const messages: Message[] = [
+      { id: "1", role: "user", content: "Hello" },
+      { id: "2", role: "assistant", content: "Hi" },
+      { id: "3", role: "data", content: "Should be filtered" } as any,
+      { id: "4", role: "system", content: "System message" },
+    ];
+
+    render(
+      <AssistantUIChat
+        codeSpace="test-space"
+        initialMessages={messages}
+      />
+    );
+
+    expect(useChatRuntime).toHaveBeenCalledWith({
+      api: "/live/test-space/messages",
+      initialMessages: [
+        { id: "1", role: "user", content: "Hello" },
+        { id: "2", role: "assistant", content: "Hi" },
+        { id: "4", role: "system", content: "System message" },
+      ],
+    });
+  });
+
+  it("should provide runtime to AssistantRuntimeProvider", () => {
+    render(
+      <AssistantUIChat
+        codeSpace="test-space"
+        initialMessages={[]}
+      />
+    );
+
+    expect(AssistantRuntimeProvider).toHaveBeenCalled();
+    const callArgs = (AssistantRuntimeProvider as any).mock.calls[0][0];
+    expect(callArgs.runtime).toBe(mockRuntime);
+  });
+
+  it("should auto-send initial prompt when provided", () => {
+    const initialPrompt = {
+      prompt: "Create a weather app",
+      images: [] as ImageData[],
+    };
+
+    render(
+      <AssistantUIChat
+        codeSpace="test-space"
+        initialMessages={[]}
+        initialPrompt={initialPrompt}
+      />
+    );
+
+    expect(mockComposerRuntime.setText).toHaveBeenCalledWith("Create a weather app");
+    expect(mockComposerRuntime.send).toHaveBeenCalled();
+  });
+
+  it("should not auto-send when initial prompt is null", () => {
+    render(
+      <AssistantUIChat
+        codeSpace="test-space"
+        initialMessages={[]}
+        initialPrompt={null}
+      />
+    );
+
+    expect(mockComposerRuntime.setText).not.toHaveBeenCalled();
+    expect(mockComposerRuntime.send).not.toHaveBeenCalled();
+  });
+
+  it("should not auto-send when initial prompt is undefined", () => {
+    render(
+      <AssistantUIChat
+        codeSpace="test-space"
+        initialMessages={[]}
+        initialPrompt={undefined}
+      />
+    );
+
+    expect(mockComposerRuntime.setText).not.toHaveBeenCalled();
+    expect(mockComposerRuntime.send).not.toHaveBeenCalled();
+  });
+
+  it("should handle initial prompt with images", () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    
+    const initialPrompt = {
+      prompt: "Analyze this design",
+      images: [
+        {
+          src: "data:image/png;base64,test1",
+          imageName: "design1.png",
+        },
+        {
+          src: "data:image/png;base64,test2",
+          imageName: "design2.png",
+        },
+      ] as ImageData[],
+    };
+
+    render(
+      <AssistantUIChat
+        codeSpace="test-space"
+        initialMessages={[]}
+        initialPrompt={initialPrompt}
+      />
+    );
+
+    expect(mockComposerRuntime.setText).toHaveBeenCalledWith("Analyze this design");
+    expect(mockComposerRuntime.send).toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Images detected in initial prompt:",
+      initialPrompt.images
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it("should handle empty initial prompt", () => {
+    const initialPrompt = {
+      prompt: "",
+      images: [] as ImageData[],
+    };
+
+    render(
+      <AssistantUIChat
+        codeSpace="test-space"
+        initialMessages={[]}
+        initialPrompt={initialPrompt}
+      />
+    );
+
+    expect(mockComposerRuntime.setText).toHaveBeenCalledWith("");
+    expect(mockComposerRuntime.send).toHaveBeenCalled();
+  });
+
+  it("should not send if thread runtime is not available", () => {
+    vi.mocked(useThreadRuntime).mockReturnValueOnce(null as any);
+
+    const initialPrompt = {
+      prompt: "Test prompt",
+      images: [] as ImageData[],
+    };
+
+    render(
+      <AssistantUIChat
+        codeSpace="test-space"
+        initialMessages={[]}
+        initialPrompt={initialPrompt}
+      />
+    );
+
+    expect(mockComposerRuntime.setText).not.toHaveBeenCalled();
+    expect(mockComposerRuntime.send).not.toHaveBeenCalled();
+  });
+
+  it("should handle runtime without composer gracefully", () => {
+    const runtimeWithoutComposer = {
+      ...mockThreadRuntime,
+      composer: undefined,
+    } as any;
+
+    vi.mocked(useThreadRuntime).mockReturnValueOnce(runtimeWithoutComposer);
+
+    const initialPrompt = {
+      prompt: "Test prompt",
+      images: [] as ImageData[],
+    };
+
+    // Should not throw, just won't send the message
+    render(
+      <AssistantUIChat
+        codeSpace="test-space"
+        initialMessages={[]}
+        initialPrompt={initialPrompt}
+      />
+    );
+
+    // Verify setText and send were not called since composer is undefined
+    expect(mockComposerRuntime.setText).not.toHaveBeenCalled();
+    expect(mockComposerRuntime.send).not.toHaveBeenCalled();
+  });
+
+  it("should only send initial prompt once", () => {
+    const initialPrompt = {
+      prompt: "Send only once",
+      images: [] as ImageData[],
+    };
+
+    const { rerender } = render(
+      <AssistantUIChat
+        codeSpace="test-space"
+        initialMessages={[]}
+        initialPrompt={initialPrompt}
+      />
+    );
+
+    expect(mockComposerRuntime.setText).toHaveBeenCalledTimes(1);
+    expect(mockComposerRuntime.send).toHaveBeenCalledTimes(1);
+
+    // Re-render with same props
+    rerender(
+      <AssistantUIChat
+        codeSpace="test-space"
+        initialMessages={[]}
+        initialPrompt={initialPrompt}
+      />
+    );
+
+    // Should not send again
+    expect(mockComposerRuntime.setText).toHaveBeenCalledTimes(1);
+    expect(mockComposerRuntime.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("should handle special characters in prompt", () => {
+    const initialPrompt = {
+      prompt: 'Create a "Hello, World!" app with <script> tags & emojis 🎉',
+      images: [] as ImageData[],
+    };
+
+    render(
+      <AssistantUIChat
+        codeSpace="test-space"
+        initialMessages={[]}
+        initialPrompt={initialPrompt}
+      />
+    );
+
+    expect(mockComposerRuntime.setText).toHaveBeenCalledWith(
+      'Create a "Hello, World!" app with <script> tags & emojis 🎉'
+    );
+    expect(mockComposerRuntime.send).toHaveBeenCalled();
+  });
+
+  it("should handle very long prompts", () => {
+    const longPrompt = "a".repeat(10000);
+    const initialPrompt = {
+      prompt: longPrompt,
+      images: [] as ImageData[],
+    };
+
+    render(
+      <AssistantUIChat
+        codeSpace="test-space"
+        initialMessages={[]}
+        initialPrompt={initialPrompt}
+      />
+    );
+
+    expect(mockComposerRuntime.setText).toHaveBeenCalledWith(longPrompt);
+    expect(mockComposerRuntime.send).toHaveBeenCalled();
+  });
+});

--- a/packages/code/src/@/components/app/__tests__/assistant-ui-chat.spec.tsx
+++ b/packages/code/src/@/components/app/__tests__/assistant-ui-chat.spec.tsx
@@ -248,7 +248,7 @@ describe("AssistantUIChat", () => {
     consoleSpy.mockRestore();
   });
 
-  it("should handle empty initial prompt", () => {
+  it("should not send empty initial prompt", () => {
     const initialPrompt = {
       prompt: "",
       images: [] as ImageData[],
@@ -262,8 +262,28 @@ describe("AssistantUIChat", () => {
       />
     );
 
-    expect(mockComposerRuntime.setText).toHaveBeenCalledWith("");
-    expect(mockComposerRuntime.send).toHaveBeenCalled();
+    // Should not send empty prompts
+    expect(mockComposerRuntime.setText).not.toHaveBeenCalled();
+    expect(mockComposerRuntime.send).not.toHaveBeenCalled();
+  });
+
+  it("should not send whitespace-only prompts", () => {
+    const initialPrompt = {
+      prompt: "   \n\t  ",
+      images: [] as ImageData[],
+    };
+
+    render(
+      <AssistantUIChat
+        codeSpace="test-space"
+        initialMessages={[]}
+        initialPrompt={initialPrompt}
+      />
+    );
+
+    // Should not send whitespace-only prompts
+    expect(mockComposerRuntime.setText).not.toHaveBeenCalled();
+    expect(mockComposerRuntime.send).not.toHaveBeenCalled();
   });
 
   it("should not send if thread runtime is not available", () => {

--- a/packages/code/src/@/components/app/__tests__/assistant-ui-drawer.spec.tsx
+++ b/packages/code/src/@/components/app/__tests__/assistant-ui-drawer.spec.tsx
@@ -1,0 +1,273 @@
+import { AssistantUIDrawer } from "@/components/app/assistant-ui-drawer";
+import { AssistantUIChat } from "@/components/app/assistant-ui-chat";
+import type { ICode, ImageData } from "@/lib/interfaces";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Message } from "ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock dependencies
+vi.mock("@/components/app/assistant-ui-chat", () => ({
+  AssistantUIChat: vi.fn(() => <div>Mocked AssistantUIChat</div>),
+}));
+vi.mock("vaul", () => ({
+  Drawer: {
+    Root: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+      open ? <div data-testid="drawer-root">{children}</div> : null,
+    Trigger: ({ children, onClick }: { children: React.ReactNode; onClick: () => void }) => (
+      <button onClick={onClick} data-testid="drawer-trigger">
+        {children}
+      </button>
+    ),
+    Portal: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="drawer-portal">{children}</div>
+    ),
+    Overlay: () => <div data-testid="drawer-overlay" />,
+    Content: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+      <div data-testid="drawer-content" className={className}>{children}</div>
+    ),
+    Title: ({ children }: { children: React.ReactNode }) => (
+      <h2 data-testid="drawer-title">{children}</h2>
+    ),
+    Description: ({ children }: { children: React.ReactNode }) => (
+      <p data-testid="drawer-description">{children}</p>
+    ),
+  },
+}));
+
+// Mock global fetch
+global.fetch = vi.fn();
+
+// Mock ICode interface
+const createMockCodeSession = (codeSpace = "test-space"): ICode => ({
+  getCodeSpace: vi.fn().mockReturnValue(codeSpace),
+  getSession: vi.fn().mockResolvedValue({}),
+} as unknown as ICode);
+
+describe("AssistantUIDrawer", () => {
+  let mockCodeSession: ICode;
+
+  const getDefaultProps = () => ({
+    isOpen: true,
+    onClose: vi.fn(),
+    isDarkMode: false,
+    cSess: mockCodeSession,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCodeSession = createMockCodeSession();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should not render when isOpen is false", () => {
+    const { container } = render(
+      <AssistantUIDrawer {...getDefaultProps()} isOpen={false} />
+    );
+
+    expect(container.querySelector('[data-testid="drawer-root"]')).toBeNull();
+  });
+
+  it("should render drawer when isOpen is true", () => {
+    render(<AssistantUIDrawer {...getDefaultProps()} />);
+
+    expect(screen.getByTestId("drawer-root")).toBeInTheDocument();
+    expect(screen.getByTestId("drawer-content")).toBeInTheDocument();
+  });
+
+  it("should load messages when drawer opens", async () => {
+    const mockMessages: Message[] = [
+      { id: "1", role: "user", content: "Hello" },
+      { id: "2", role: "assistant", content: "Hi there!" },
+    ];
+
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ messages: mockMessages }),
+    } as Response);
+
+    render(<AssistantUIDrawer {...getDefaultProps()} />);
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith("/live/test-space/messages");
+    });
+
+    await waitFor(() => {
+      expect(AssistantUIChat).toHaveBeenCalled();
+      const callArgs = (AssistantUIChat as any).mock.calls[0][0];
+      expect(callArgs.codeSpace).toBe("test-space");
+      expect(callArgs.initialMessages).toEqual(mockMessages);
+      expect(callArgs.initialPrompt).toBeUndefined();
+    });
+  });
+
+  it("should pass initial prompt to AssistantUIChat", async () => {
+    const mockInitialPrompt = {
+      prompt: "Create a calculator app",
+      images: [
+        {
+          src: "data:image/png;base64,test",
+          imageName: "mockup.png",
+        },
+      ] as ImageData[],
+    };
+
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ messages: [] }),
+    } as Response);
+
+    render(<AssistantUIDrawer {...getDefaultProps()} initialPrompt={mockInitialPrompt} />);
+
+    await waitFor(() => {
+      expect(AssistantUIChat).toHaveBeenCalled();
+      const callArgs = (AssistantUIChat as any).mock.calls[0][0];
+      expect(callArgs.initialPrompt).toEqual(mockInitialPrompt);
+    });
+  });
+
+  it("should handle fetch error gracefully", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(fetch).mockRejectedValueOnce(new Error("Network error"));
+
+    render(<AssistantUIDrawer {...getDefaultProps()} />);
+
+    await waitFor(() => {
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "Failed to load messages:",
+        expect.any(Error)
+      );
+    });
+
+    // Should still render with empty messages
+    await waitFor(() => {
+      expect(AssistantUIChat).toHaveBeenCalled();
+      const callArgs = (AssistantUIChat as any).mock.calls[0][0];
+      expect(callArgs.initialMessages).toEqual([]);
+    });
+
+    consoleSpy.mockRestore();
+  });
+
+  it("should handle non-ok response", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    } as Response);
+
+    render(<AssistantUIDrawer {...getDefaultProps()} />);
+
+    await waitFor(() => {
+      expect(AssistantUIChat).toHaveBeenCalled();
+      const callArgs = (AssistantUIChat as any).mock.calls[0][0];
+      expect(callArgs.initialMessages).toEqual([]);
+    });
+  });
+
+  it("should apply dark mode classes correctly", () => {
+    render(<AssistantUIDrawer {...getDefaultProps()} isDarkMode={true} />);
+
+    const content = screen.getByTestId("drawer-content");
+    expect(content.className).toContain("bg-gray-800");
+    expect(content.className).toContain("text-white");
+  });
+
+  it("should apply light mode classes correctly", () => {
+    render(<AssistantUIDrawer {...getDefaultProps()} isDarkMode={false} />);
+
+    const content = screen.getByTestId("drawer-content");
+    expect(content.className).toContain("bg-gray-100");
+    expect(content.className).toContain("text-gray-800");
+  });
+
+  it("should sync dark mode with document", () => {
+    const { rerender } = render(<AssistantUIDrawer {...getDefaultProps()} isDarkMode={false} />);
+
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+
+    rerender(<AssistantUIDrawer {...getDefaultProps()} isDarkMode={true} />);
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("should call onClose when close button is clicked", async () => {
+    const onCloseMock = vi.fn();
+    render(<AssistantUIDrawer {...getDefaultProps()} onClose={onCloseMock} />);
+
+    // Find the close button (the second button in the drawer)
+    const buttons = screen.getAllByRole("button");
+    const closeButton = buttons.find(button => 
+      button.className.includes("p-2 rounded-lg hover:bg-gray-200")
+    );
+    
+    if (closeButton) {
+      await userEvent.click(closeButton);
+      expect(onCloseMock).toHaveBeenCalled();
+    } else {
+      throw new Error("Close button not found");
+    }
+  });
+
+  it("should render loading state while messages are being fetched", () => {
+    vi.mocked(fetch).mockImplementation(
+      () => new Promise(() => {}) // Never resolves
+    );
+
+    render(<AssistantUIDrawer {...getDefaultProps()} />);
+
+    expect(screen.getByText("Loading messages...")).toBeInTheDocument();
+    expect(AssistantUIChat).not.toHaveBeenCalled();
+  });
+
+  it("should only load messages once when drawer is kept open", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ messages: [] }),
+    } as Response);
+
+    const { rerender } = render(<AssistantUIDrawer {...getDefaultProps()} />);
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    // Re-render with same props
+    rerender(<AssistantUIDrawer {...getDefaultProps()} />);
+
+    // Should not fetch again
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("should handle null initial prompt correctly", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ messages: [] }),
+    } as Response);
+
+    render(<AssistantUIDrawer {...getDefaultProps()} initialPrompt={null} />);
+
+    await waitFor(() => {
+      expect(AssistantUIChat).toHaveBeenCalled();
+      const callArgs = (AssistantUIChat as any).mock.calls[0][0];
+      expect(callArgs.initialPrompt).toBeNull();
+    });
+  });
+
+  it("should handle undefined initial prompt correctly", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ messages: [] }),
+    } as Response);
+
+    render(<AssistantUIDrawer {...getDefaultProps()} initialPrompt={undefined} />);
+
+    await waitFor(() => {
+      expect(AssistantUIChat).toHaveBeenCalled();
+      const callArgs = (AssistantUIChat as any).mock.calls[0][0];
+      expect(callArgs.initialPrompt).toBeUndefined();
+    });
+  });
+});

--- a/packages/code/src/@/components/app/__tests__/assistant-ui-drawer.spec.tsx
+++ b/packages/code/src/@/components/app/__tests__/assistant-ui-drawer.spec.tsx
@@ -111,6 +111,10 @@ describe("AssistantUIDrawer", () => {
         {
           src: "data:image/png;base64,test",
           imageName: "mockup.png",
+          url: "http://example.com/mockup.png",
+          mediaType: "image/png",
+          data: "test",
+          type: "image",
         },
       ] as ImageData[],
     };

--- a/packages/code/src/@/components/app/__tests__/assistant-ui-drawer.spec.tsx
+++ b/packages/code/src/@/components/app/__tests__/assistant-ui-drawer.spec.tsx
@@ -411,7 +411,7 @@ describe("AssistantUIDrawer", () => {
     });
 
     // Store the initial call count
-    const _initialCallCount = vi.mocked(AssistantUIChat).mock.calls.length;
+    // const _initialCallCount = vi.mocked(AssistantUIChat).mock.calls.length;
 
     // Close and reopen with new messages
     rerender(<AssistantUIDrawer {...getDefaultProps()} isOpen={false} />);

--- a/packages/code/src/@/components/app/assistant-ui-chat.tsx
+++ b/packages/code/src/@/components/app/assistant-ui-chat.tsx
@@ -4,6 +4,7 @@ import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
 import React, { useEffect } from "react";
 import type { Message } from "ai";
 import type { ImageData } from "@/lib/interfaces";
+import type { ThreadMessageLike } from "@assistant-ui/react";
 
 interface AssistantUIChatProps {
   codeSpace: string;
@@ -24,7 +25,7 @@ export const AssistantUIChat: React.FC<AssistantUIChatProps> = React.memo(
     // Create runtime with initial messages
     const runtime = useChatRuntime({
       api: `/live/${codeSpace}/messages`,
-      initialMessages: filteredMessages as Message[], // Type assertion for compatibility
+      initialMessages: filteredMessages as unknown as ThreadMessageLike[],
     });
 
     return (

--- a/packages/code/src/@/components/app/assistant-ui-chat.tsx
+++ b/packages/code/src/@/components/app/assistant-ui-chat.tsx
@@ -1,7 +1,7 @@
 import { Thread } from "@/components/assistant-ui/thread";
 import { AssistantRuntimeProvider, useThreadRuntime } from "@assistant-ui/react";
 import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import type { Message } from "ai";
 import type { ImageData } from "@/lib/interfaces";
 import type { ThreadMessageLike } from "@assistant-ui/react";
@@ -45,13 +45,23 @@ const AutoSendInitialPrompt: React.FC<{
   } | null | undefined;
 }> = ({ initialPrompt }) => {
   const threadRuntime = useThreadRuntime();
+  const hasSentRef = useRef(false);
   
   useEffect(() => {
-    if (initialPrompt && threadRuntime) {
+    // Prevent multiple sends and validate prompt
+    if (
+      initialPrompt && 
+      threadRuntime && 
+      !hasSentRef.current &&
+      initialPrompt.prompt.trim() // Only send non-empty prompts
+    ) {
       // Get the composer runtime from the thread runtime
       const composerRuntime = threadRuntime.composer;
       
       if (composerRuntime) {
+        // Mark as sent before actually sending to prevent race conditions
+        hasSentRef.current = true;
+        
         // Set the text and send it
         composerRuntime.setText(initialPrompt.prompt);
         composerRuntime.send();

--- a/packages/code/src/@/components/app/assistant-ui-chat.tsx
+++ b/packages/code/src/@/components/app/assistant-ui-chat.tsx
@@ -1,16 +1,21 @@
 import { Thread } from "@/components/assistant-ui/thread";
-import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import { AssistantRuntimeProvider, useThreadRuntime } from "@assistant-ui/react";
 import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
-import React from "react";
+import React, { useEffect } from "react";
 import type { Message } from "ai";
+import type { ImageData } from "@/lib/interfaces";
 
 interface AssistantUIChatProps {
   codeSpace: string;
   initialMessages: Message[];
+  initialPrompt?: {
+    prompt: string;
+    images: ImageData[];
+  } | null | undefined;
 }
 
 export const AssistantUIChat: React.FC<AssistantUIChatProps> = React.memo(
-  ({ codeSpace, initialMessages }) => {
+  ({ codeSpace, initialMessages, initialPrompt }) => {
     // Filter out messages with 'data' role as they're not supported by ThreadMessageLike
     const filteredMessages = initialMessages.filter(
       msg => msg.role === 'user' || msg.role === 'assistant' || msg.role === 'system'
@@ -19,15 +24,47 @@ export const AssistantUIChat: React.FC<AssistantUIChatProps> = React.memo(
     // Create runtime with initial messages
     const runtime = useChatRuntime({
       api: `/live/${codeSpace}/messages`,
-      initialMessages: filteredMessages as any, // Type assertion to bypass strict type checking
+      initialMessages: filteredMessages as Message[], // Type assertion for compatibility
     });
 
     return (
       <AssistantRuntimeProvider runtime={runtime}>
         <Thread />
+        <AutoSendInitialPrompt initialPrompt={initialPrompt} />
       </AssistantRuntimeProvider>
     );
   }
 );
+
+// Component to handle auto-sending the initial prompt
+const AutoSendInitialPrompt: React.FC<{
+  initialPrompt?: {
+    prompt: string;
+    images: ImageData[];
+  } | null | undefined;
+}> = ({ initialPrompt }) => {
+  const threadRuntime = useThreadRuntime();
+  
+  useEffect(() => {
+    if (initialPrompt && threadRuntime) {
+      // Get the composer runtime from the thread runtime
+      const composerRuntime = threadRuntime.composer;
+      
+      if (composerRuntime) {
+        // Set the text and send it
+        composerRuntime.setText(initialPrompt.prompt);
+        composerRuntime.send();
+        
+        // TODO: Handle images if needed in the future
+        if (initialPrompt.images.length > 0) {
+          console.log("Images detected in initial prompt:", initialPrompt.images);
+          // Images will need to be handled based on the API's capability
+        }
+      }
+    }
+  }, [initialPrompt, threadRuntime]);
+  
+  return null;
+};
 
 AssistantUIChat.displayName = "AssistantUIChat";

--- a/packages/code/src/@/components/app/assistant-ui-drawer.tsx
+++ b/packages/code/src/@/components/app/assistant-ui-drawer.tsx
@@ -25,7 +25,7 @@ export const AssistantUIDrawer: React.FC<AssistantUIDrawerProps> = React.memo(
 
     // Load existing messages when drawer opens
     useEffect(() => {
-      if (isOpen && !messagesLoaded) {
+      if (isOpen) {
         const loadMessages = async () => {
           try {
             const response = await fetch(`/live/${codeSpace}/messages`);
@@ -42,9 +42,10 @@ export const AssistantUIDrawer: React.FC<AssistantUIDrawerProps> = React.memo(
           }
         };
         
+        setMessagesLoaded(false); // Reset to show loading state
         loadMessages();
       }
-    }, [isOpen, codeSpace, messagesLoaded]);
+    }, [isOpen, codeSpace]);
 
 
     // Sync dark mode with Assistant UI
@@ -124,6 +125,7 @@ export const AssistantUIDrawer: React.FC<AssistantUIDrawerProps> = React.memo(
               {/* Assistant UI Thread */}
               {messagesLoaded ? (
                 <AssistantUIChat 
+                  key={`${codeSpace}-${savedMessages.length}`}
                   codeSpace={codeSpace} 
                   initialMessages={savedMessages} 
                   initialPrompt={initialPrompt}

--- a/packages/code/src/@/components/app/assistant-ui-drawer.tsx
+++ b/packages/code/src/@/components/app/assistant-ui-drawer.tsx
@@ -1,5 +1,5 @@
 import { Bot } from "@/external/lucide-react";
-import type { ICode } from "@/lib/interfaces";
+import type { ICode, ImageData } from "@/lib/interfaces";
 import { cn } from "@/lib/utils";
 import React, { useEffect, useState } from "react";
 import { Drawer } from "vaul";
@@ -11,10 +11,14 @@ interface AssistantUIDrawerProps {
   onClose: () => void;
   isDarkMode: boolean;
   cSess: ICode;
+  initialPrompt?: {
+    prompt: string;
+    images: ImageData[];
+  } | null | undefined;
 }
 
 export const AssistantUIDrawer: React.FC<AssistantUIDrawerProps> = React.memo(
-  ({ isOpen, onClose, isDarkMode, cSess: _cSess }) => {
+  ({ isOpen, onClose, isDarkMode, cSess: _cSess, initialPrompt }) => {
     const codeSpace = _cSess.getCodeSpace();
     const [messagesLoaded, setMessagesLoaded] = useState(false);
     const [savedMessages, setSavedMessages] = useState<Message[]>([]);
@@ -122,6 +126,7 @@ export const AssistantUIDrawer: React.FC<AssistantUIDrawerProps> = React.memo(
                 <AssistantUIChat 
                   codeSpace={codeSpace} 
                   initialMessages={savedMessages} 
+                  initialPrompt={initialPrompt}
                 />
               ) : (
                 <div className="flex items-center justify-center h-full">

--- a/packages/code/src/@/components/assistant-ui/__tests__/thread.spec.tsx
+++ b/packages/code/src/@/components/assistant-ui/__tests__/thread.spec.tsx
@@ -1,0 +1,303 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+// Mock assistant-ui components
+vi.mock("@assistant-ui/react", () => ({
+  ThreadPrimitive: {
+    Root: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    Viewport: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    Messages: ({ components }: any) => {
+      // Simulate rendering messages based on mock data
+      const mockMessages = (window as any).__mockMessages || [];
+      return (
+        <div data-testid="messages">
+          {mockMessages.map((msg: any, idx: number) => {
+            if (msg.role === "user" && components.UserMessage) {
+              return <components.UserMessage key={idx} />;
+            }
+            if (msg.role === "assistant" && components.AssistantMessage) {
+              return <components.AssistantMessage key={idx} />;
+            }
+            return null;
+          })}
+        </div>
+      );
+    },
+    Empty: ({ children }: any) => {
+      const hasMessages = ((window as any).__mockMessages || []).length > 0;
+      return hasMessages ? null : <div>{children}</div>;
+    },
+    If: ({ children, running, empty }: any) => {
+      if (running !== undefined) {
+        const isRunning = (window as any).__mockIsRunning || false;
+        return running === isRunning ? <div>{children}</div> : null;
+      }
+      if (empty !== undefined) {
+        const hasMessages = ((window as any).__mockMessages || []).length > 0;
+        return empty === !hasMessages ? <div>{children}</div> : null;
+      }
+      return <div>{children}</div>;
+    },
+    ScrollToBottom: ({ children, ...props }: any) => (
+      <button {...props}>{children}</button>
+    ),
+    Suggestion: ({ children, prompt, ...props }: any) => (
+      <button {...props}>{children || prompt}</button>
+    ),
+  },
+  ComposerPrimitive: {
+    Root: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    Input: (props: any) => <textarea {...props} />,
+    Send: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+    Cancel: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  },
+  MessagePrimitive: {
+    Root: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    Parts: ({ components }: any) => {
+      const currentMessage = (window as any).__currentMessage || { content: [] };
+      return (
+        <div data-testid="message-parts">
+          {currentMessage.content.map((part: any, idx: number) => {
+            if (part.type === "text") {
+              const TextComponent = components?.Text || (({ text }: any) => <span>{text}</span>);
+              return <TextComponent key={idx} text={part.text} />;
+            }
+            if (part.type === "tool-call" && components?.tools?.Fallback) {
+              const ToolComponent = components.tools.Fallback;
+              return (
+                <ToolComponent
+                  key={idx}
+                  toolName={part.toolName}
+                  toolCallId={part.toolCallId}
+                  args={part.args}
+                  result={part.result}
+                />
+              );
+            }
+            return null;
+          })}
+          {components?.ToolGroup && currentMessage.hasConsecutiveTools && (
+            <components.ToolGroup>Tool Group Content</components.ToolGroup>
+          )}
+        </div>
+      );
+    },
+    If: ({ children }: any) => <div>{children}</div>,
+  },
+  ActionBarPrimitive: {
+    Root: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    Edit: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+    Copy: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+    Reload: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  },
+  BranchPickerPrimitive: {
+    Root: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    Previous: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+    Next: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+    Number: () => <span>1</span>,
+    Count: () => <span>1</span>,
+  },
+}));
+
+// Mock child components
+vi.mock("../markdown-text", () => ({
+  MarkdownText: ({ text }: { text: string }) => <span>{text}</span>,
+}));
+
+vi.mock("../tooltip-icon-button", () => ({
+  TooltipIconButton: ({ children, tooltip, ...props }: any) => (
+    <button {...props} title={tooltip}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("../tool-call", () => ({
+  ToolCall: ({ name, args, result, isExecuting }: any) => (
+    <div data-testid="tool-call">
+      <button>{name}</button>
+      {args && <div>Parameters</div>}
+      {result && <div>Result</div>}
+      {isExecuting && <div>Executing...</div>}
+    </div>
+  ),
+  ToolCallGroup: ({ children }: any) => (
+    <div data-testid="tool-call-group">
+      <div>Tool Calls</div>
+      {children}
+    </div>
+  ),
+}));
+
+// Import after mocks
+import { Thread } from "../thread";
+
+describe("Thread", () => {
+  beforeEach(() => {
+    // Reset mock data
+    (window as any).__mockMessages = [];
+    (window as any).__mockIsRunning = false;
+    (window as any).__currentMessage = null;
+  });
+
+  afterEach(() => {
+    delete (window as any).__mockMessages;
+    delete (window as any).__mockIsRunning;
+    delete (window as any).__currentMessage;
+  });
+
+  it("renders thread container correctly", () => {
+    render(<Thread />);
+    expect(screen.getByText("How can I help you today?")).toBeInTheDocument();
+  });
+
+  it("renders welcome suggestions", () => {
+    render(<Thread />);
+    expect(screen.getByText("What is the weather in Tokyo?")).toBeInTheDocument();
+    expect(screen.getByText("What is assistant-ui?")).toBeInTheDocument();
+  });
+
+  it("renders composer with placeholder text", () => {
+    render(<Thread />);
+    const input = screen.getByPlaceholderText("Write a message...");
+    expect(input).toBeInTheDocument();
+  });
+
+  describe("with messages containing tool calls", () => {
+    it("renders tool calls in messages", () => {
+      // Set up mock message with tool call
+      (window as any).__mockMessages = [
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Let me search for that." },
+            {
+              type: "tool-call",
+              toolCallId: "tc1",
+              toolName: "search",
+              args: { query: "AI news" },
+              result: { results: ["News 1", "News 2"] },
+            },
+          ],
+        },
+      ];
+
+      // Mock the current message for MessagePrimitive.Parts
+      (window as any).__currentMessage = (window as any).__mockMessages[0];
+
+      render(<Thread />);
+
+      // Check that the tool call component is rendered
+      const toolCall = screen.getByTestId("tool-call");
+      expect(toolCall).toBeInTheDocument();
+      expect(screen.getByText("search")).toBeInTheDocument();
+    });
+
+    it("expands tool call details when clicked", () => {
+      (window as any).__mockMessages = [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "tc1",
+              toolName: "search_web",
+              args: { query: "latest AI news" },
+              result: { results: ["News 1", "News 2"] },
+            },
+          ],
+        },
+      ];
+
+      (window as any).__currentMessage = (window as any).__mockMessages[0];
+
+      render(<Thread />);
+
+      const toolButton = screen.getByText("search_web");
+      expect(toolButton).toBeInTheDocument();
+
+      // Our mock always shows Parameters and Result when they exist
+      expect(screen.getByText("Parameters")).toBeInTheDocument();
+      expect(screen.getByText("Result")).toBeInTheDocument();
+    });
+
+    it("renders multiple tool calls", () => {
+      (window as any).__mockMessages = [
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "I'll gather multiple pieces of information." },
+            {
+              type: "tool-call",
+              toolCallId: "tc1",
+              toolName: "get_weather",
+              args: { city: "London" },
+            },
+            {
+              type: "tool-call",
+              toolCallId: "tc2",
+              toolName: "get_time",
+              args: { timezone: "Europe/London" },
+            },
+          ],
+        },
+      ];
+
+      (window as any).__currentMessage = (window as any).__mockMessages[0];
+
+      render(<Thread />);
+
+      // All tool calls should be rendered
+      expect(screen.getByText("get_weather")).toBeInTheDocument();
+      expect(screen.getByText("get_time")).toBeInTheDocument();
+    });
+
+    it("shows tool group for consecutive tools", () => {
+      (window as any).__mockMessages = [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "tc1",
+              toolName: "tool1",
+              args: {},
+            },
+          ],
+          hasConsecutiveTools: true,
+        },
+      ];
+
+      (window as any).__currentMessage = (window as any).__mockMessages[0];
+
+      render(<Thread />);
+
+      expect(screen.getByTestId("tool-call-group")).toBeInTheDocument();
+      expect(screen.getByText("Tool Calls")).toBeInTheDocument();
+    });
+  });
+
+  describe("UI elements", () => {
+    it("shows scroll to bottom button", () => {
+      render(<Thread />);
+      const scrollButton = screen.getByTitle("Scroll to bottom");
+      expect(scrollButton).toBeInTheDocument();
+    });
+
+    it("shows send button when not running", () => {
+      (window as any).__mockIsRunning = false;
+      render(<Thread />);
+      
+      const sendButton = screen.getByTitle("Send");
+      expect(sendButton).toBeInTheDocument();
+    });
+
+    it("shows cancel button when running", () => {
+      (window as any).__mockIsRunning = true;
+      render(<Thread />);
+      
+      const cancelButton = screen.getByTitle("Cancel");
+      expect(cancelButton).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/code/src/@/components/assistant-ui/__tests__/tool-call.spec.tsx
+++ b/packages/code/src/@/components/assistant-ui/__tests__/tool-call.spec.tsx
@@ -1,0 +1,225 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { ToolCall, ToolCallGroup } from "../tool-call";
+
+describe("ToolCall", () => {
+  const defaultProps = {
+    name: "test_tool",
+    args: { param1: "value1", param2: 123 },
+    result: { output: "test result" },
+  };
+
+  it("renders tool name correctly", () => {
+    render(<ToolCall {...defaultProps} />);
+    expect(screen.getByText("test_tool")).toBeInTheDocument();
+  });
+
+  it("shows wrench icon", () => {
+    const { container } = render(<ToolCall {...defaultProps} />);
+    const icon = container.querySelector("svg");
+    expect(icon).toBeInTheDocument();
+  });
+
+  it("toggles expansion when clicked", () => {
+    render(<ToolCall {...defaultProps} />);
+    
+    // Initially collapsed - should not show parameters
+    expect(screen.queryByText("Parameters")).not.toBeInTheDocument();
+    
+    // Click to expand
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+    
+    // Should now show parameters
+    expect(screen.getByText("Parameters")).toBeInTheDocument();
+    expect(screen.getByText("Result")).toBeInTheDocument();
+  });
+
+  it("displays parameters in JSON format when expanded", () => {
+    render(<ToolCall {...defaultProps} />);
+    
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+    
+    // Check if JSON is displayed correctly
+    expect(screen.getByText(/"param1":/)).toBeInTheDocument();
+    expect(screen.getByText(/"value1"/)).toBeInTheDocument();
+    expect(screen.getByText(/"param2":/)).toBeInTheDocument();
+    expect(screen.getByText(/123/)).toBeInTheDocument();
+  });
+
+  it("displays result when available", () => {
+    render(<ToolCall {...defaultProps} />);
+    
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+    
+    expect(screen.getByText(/"output":/)).toBeInTheDocument();
+    expect(screen.getByText(/"test result"/)).toBeInTheDocument();
+  });
+
+  it("displays string result directly", () => {
+    render(<ToolCall name="test_tool" result="Simple string result" />);
+    
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+    
+    expect(screen.getByText("Simple string result")).toBeInTheDocument();
+  });
+
+  it("shows executing state", () => {
+    render(<ToolCall name="test_tool" isExecuting={true} />);
+    
+    expect(screen.getByText("Executing...")).toBeInTheDocument();
+  });
+
+  it("does not show parameters section when args is empty", () => {
+    render(<ToolCall name="test_tool" args={{}} />);
+    
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+    
+    expect(screen.queryByText("Parameters")).not.toBeInTheDocument();
+  });
+
+  it("does not show result section when result is undefined", () => {
+    render(<ToolCall name="test_tool" args={{ test: "value" }} />);
+    
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+    
+    expect(screen.queryByText("Result")).not.toBeInTheDocument();
+  });
+
+  it("applies custom className", () => {
+    const { container } = render(
+      <ToolCall {...defaultProps} className="custom-class" />
+    );
+    
+    const toolCallDiv = container.firstChild;
+    expect(toolCallDiv).toHaveClass("custom-class");
+  });
+
+  it("changes chevron icon direction when toggled", () => {
+    render(<ToolCall {...defaultProps} />);
+    
+    // Initially shows right chevron (check by finding the button and its svg)
+    const button = screen.getByRole("button");
+    let svgs = button.querySelectorAll("svg");
+    expect(svgs.length).toBeGreaterThan(0);
+    
+    // The first SVG should be the chevron
+    const initialChevron = svgs[0];
+    expect(initialChevron).toBeTruthy();
+    
+    // Click to expand
+    fireEvent.click(button);
+    
+    // Should now show down chevron - get fresh SVGs after click
+    svgs = button.querySelectorAll("svg");
+    expect(svgs.length).toBeGreaterThan(0);
+    
+    // We can't easily test the specific icon type without inspecting the path
+    // but we can verify the button still has an icon
+    const expandedChevron = svgs[0];
+    expect(expandedChevron).toBeTruthy();
+  });
+
+  it("handles very long parameter values gracefully", () => {
+    const longValue = "a".repeat(1000);
+    render(
+      <ToolCall
+        name="test_tool"
+        args={{ longParam: longValue }}
+      />
+    );
+    
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+    
+    const preElement = screen.getByText((content, element) => {
+      return element?.tagName === "PRE" && content.includes("longParam");
+    });
+    
+    expect(preElement).toHaveClass("overflow-x-auto");
+  });
+
+  it("handles very long result values with scrolling", () => {
+    const longResult = { data: "b".repeat(1000) };
+    render(
+      <ToolCall
+        name="test_tool"
+        result={longResult}
+      />
+    );
+    
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+    
+    const resultPre = screen.getAllByRole("generic").find(el => 
+      el.tagName === "PRE" && el.textContent?.includes("data")
+    );
+    
+    expect(resultPre).toHaveClass("max-h-48", "overflow-y-auto");
+  });
+});
+
+describe("ToolCallGroup", () => {
+  it("renders with tool calls label", () => {
+    render(
+      <ToolCallGroup>
+        <div>Child content</div>
+      </ToolCallGroup>
+    );
+    
+    expect(screen.getByText("Tool Calls")).toBeInTheDocument();
+  });
+
+  it("shows wrench icon in group header", () => {
+    const { container } = render(
+      <ToolCallGroup>
+        <div>Child content</div>
+      </ToolCallGroup>
+    );
+    
+    const icon = container.querySelector("svg");
+    expect(icon).toBeInTheDocument();
+  });
+
+  it("renders children correctly", () => {
+    render(
+      <ToolCallGroup>
+        <div data-testid="child-1">First tool</div>
+        <div data-testid="child-2">Second tool</div>
+      </ToolCallGroup>
+    );
+    
+    expect(screen.getByTestId("child-1")).toBeInTheDocument();
+    expect(screen.getByTestId("child-2")).toBeInTheDocument();
+  });
+
+  it("applies correct styling classes", () => {
+    const { container } = render(
+      <ToolCallGroup>
+        <div>Child</div>
+      </ToolCallGroup>
+    );
+    
+    const groupDiv = container.firstChild;
+    expect(groupDiv).toHaveClass("rounded-lg", "border", "bg-muted/10", "p-2", "my-2");
+  });
+
+  it("renders multiple ToolCall components correctly", () => {
+    render(
+      <ToolCallGroup>
+        <ToolCall name="tool1" args={{ a: 1 }} />
+        <ToolCall name="tool2" args={{ b: 2 }} />
+        <ToolCall name="tool3" result="Done" />
+      </ToolCallGroup>
+    );
+    
+    expect(screen.getByText("tool1")).toBeInTheDocument();
+    expect(screen.getByText("tool2")).toBeInTheDocument();
+    expect(screen.getByText("tool3")).toBeInTheDocument();
+  });
+});

--- a/packages/code/src/@/components/assistant-ui/thread.tsx
+++ b/packages/code/src/@/components/assistant-ui/thread.tsx
@@ -21,6 +21,7 @@ import type { FC } from "react";
 import { MarkdownText } from "@/components/assistant-ui/markdown-text";
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
 import { Button } from "@/components/ui/button";
+import { ToolCall, ToolCallGroup } from "@/components/assistant-ui/tool-call";
 
 export const Thread: FC = () => {
   return (
@@ -157,7 +158,22 @@ const UserMessage: FC = () => {
       <UserActionBar />
 
       <div className="bg-muted text-foreground col-start-2 row-start-2 max-w-[calc(var(--thread-max-width)*0.8)] break-words rounded-3xl px-5 py-2.5">
-        <MessagePrimitive.Parts />
+        <MessagePrimitive.Parts
+          components={{
+            Text: ({ text }) => <span>{text}</span>,
+            tools: {
+              Fallback: ({ toolName, args, result }) => (
+                <ToolCall
+                  name={toolName}
+                  args={args}
+                  result={result}
+                  isExecuting={false}
+                />
+              ),
+            },
+            ToolGroup: ({ children }) => <ToolCallGroup>{children}</ToolCallGroup>,
+          }}
+        />
       </div>
 
       <BranchPicker className="col-span-full col-start-1 row-start-3 -mr-1 justify-end" />
@@ -202,7 +218,22 @@ const AssistantMessage: FC = () => {
   return (
     <MessagePrimitive.Root className="relative grid w-full max-w-[var(--thread-max-width)] grid-cols-[auto_auto_1fr] grid-rows-[auto_1fr] py-4">
       <div className="text-foreground col-span-2 col-start-2 row-start-1 my-1.5 max-w-[calc(var(--thread-max-width)*0.8)] break-words leading-7">
-        <MessagePrimitive.Parts components={{ Text: MarkdownText }} />
+        <MessagePrimitive.Parts
+          components={{
+            Text: MarkdownText,
+            tools: {
+              Fallback: ({ toolName, args, result }) => (
+                <ToolCall
+                  name={toolName}
+                  args={args}
+                  result={result}
+                  isExecuting={false}
+                />
+              ),
+            },
+            ToolGroup: ({ children }) => <ToolCallGroup>{children}</ToolCallGroup>,
+          }}
+        />
       </div>
 
       <AssistantActionBar />

--- a/packages/code/src/@/components/assistant-ui/tool-call.tsx
+++ b/packages/code/src/@/components/assistant-ui/tool-call.tsx
@@ -1,0 +1,90 @@
+import { cn } from "@/lib/utils";
+import { ChevronRightIcon, ChevronDownIcon, WrenchIcon } from "lucide-react";
+import { useState } from "react";
+import type { FC } from "react";
+
+interface ToolCallProps {
+  name: string;
+  args?: Record<string, unknown>;
+  result?: unknown;
+  isExecuting?: boolean;
+  className?: string;
+}
+
+export const ToolCall: FC<ToolCallProps> = ({
+  name,
+  args,
+  result,
+  isExecuting = false,
+  className,
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  return (
+    <div
+      className={cn(
+        "border border-border/50 rounded-lg overflow-hidden my-2",
+        className
+      )}
+    >
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="w-full flex items-center gap-2 px-3 py-2 bg-muted/30 hover:bg-muted/50 transition-colors text-left"
+      >
+        {isExpanded ? (
+          <ChevronDownIcon className="w-4 h-4 text-muted-foreground" />
+        ) : (
+          <ChevronRightIcon className="w-4 h-4 text-muted-foreground" />
+        )}
+        <WrenchIcon className="w-4 h-4 text-primary" />
+        <span className="font-mono text-sm font-medium">{name}</span>
+        {isExecuting && (
+          <span className="ml-auto text-xs text-muted-foreground animate-pulse">
+            Executing...
+          </span>
+        )}
+      </button>
+      
+      {isExpanded && (
+        <div className="border-t border-border/50">
+          {args && Object.keys(args).length > 0 && (
+            <div className="px-3 py-2 border-b border-border/50">
+              <div className="text-xs font-medium text-muted-foreground mb-1">
+                Parameters
+              </div>
+              <pre className="text-xs font-mono bg-muted/20 rounded p-2 overflow-x-auto">
+                {JSON.stringify(args, null, 2)}
+              </pre>
+            </div>
+          )}
+          
+          {result !== undefined && (
+            <div className="px-3 py-2">
+              <div className="text-xs font-medium text-muted-foreground mb-1">
+                Result
+              </div>
+              <pre className="text-xs font-mono bg-muted/20 rounded p-2 overflow-x-auto max-h-48 overflow-y-auto">
+                {typeof result === "string" 
+                  ? result 
+                  : JSON.stringify(result, null, 2)}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+// Component to group multiple consecutive tool calls
+export const ToolCallGroup: FC<{ children: React.ReactNode }> = ({ children }) => {
+  return (
+    <div className="rounded-lg border border-border/50 bg-muted/10 p-2 my-2">
+      <div className="text-xs font-medium text-muted-foreground mb-2 flex items-center gap-1">
+        <WrenchIcon className="w-3 h-3" />
+        Tool Calls
+      </div>
+      {children}
+    </div>
+  );
+};

--- a/packages/code/src/@/lib/__tests__/render-messages.spec.tsx
+++ b/packages/code/src/@/lib/__tests__/render-messages.spec.tsx
@@ -1,0 +1,381 @@
+import { describe, it, expect } from "vitest";
+import { renderMessage } from "../render-messages";
+
+// Extended Message type for testing
+interface Message {
+  id: string;
+  role: "user" | "system" | "assistant" | "tool" | "data";
+  content: string;
+  tool_calls?: Array<{
+    id: string;
+    type: "function";
+    function: {
+      name: string;
+      arguments: string;
+    };
+  }>;
+  tool_call_id?: string;
+}
+
+describe("renderMessage with tool calls", () => {
+  it("should render text content for messages without tool calls", () => {
+    const message: Message = {
+      id: "1",
+      role: "assistant",
+      content: "Hello, this is a simple message",
+    };
+
+    const result = renderMessage(message);
+    expect(result).toEqual([
+      { type: "text", text: "Hello, this is a simple message" },
+    ]);
+  });
+
+  it("should handle messages with single tool call", () => {
+    const message: Message = {
+      id: "1",
+      role: "assistant",
+      content: "Let me search for that.",
+      tool_calls: [
+        {
+          id: "tool_1",
+          type: "function",
+          function: {
+            name: "search",
+            arguments: JSON.stringify({ query: "AI news" }),
+          },
+        },
+      ],
+    };
+
+    const result = renderMessage(message);
+    expect(result).toEqual([
+      { type: "text", text: "Let me search for that." },
+      {
+        type: "tool-call",
+        toolCallId: "tool_1",
+        toolName: "search",
+        args: { query: "AI news" },
+      },
+    ]);
+  });
+
+  it("should handle messages with multiple tool calls", () => {
+    const message: Message = {
+      id: "1",
+      role: "assistant",
+      content: "I'll gather multiple pieces of information.",
+      tool_calls: [
+        {
+          id: "tool_1",
+          type: "function",
+          function: {
+            name: "get_weather",
+            arguments: JSON.stringify({ city: "London" }),
+          },
+        },
+        {
+          id: "tool_2",
+          type: "function",
+          function: {
+            name: "get_time",
+            arguments: JSON.stringify({ timezone: "Europe/London" }),
+          },
+        },
+      ],
+    };
+
+    const result = renderMessage(message);
+    expect(result).toEqual([
+      { type: "text", text: "I'll gather multiple pieces of information." },
+      {
+        type: "tool-call",
+        toolCallId: "tool_1",
+        toolName: "get_weather",
+        args: { city: "London" },
+      },
+      {
+        type: "tool-call",
+        toolCallId: "tool_2",
+        toolName: "get_time",
+        args: { timezone: "Europe/London" },
+      },
+    ]);
+  });
+
+  it("should handle tool calls with invalid JSON arguments", () => {
+    const message: Message = {
+      id: "1",
+      role: "assistant",
+      content: "Processing...",
+      tool_calls: [
+        {
+          id: "tool_1",
+          type: "function",
+          function: {
+            name: "broken_tool",
+            arguments: "not valid json {",
+          },
+        },
+      ],
+    };
+
+    const result = renderMessage(message);
+    expect(result).toEqual([
+      { type: "text", text: "Processing..." },
+      {
+        type: "tool-call",
+        toolCallId: "tool_1",
+        toolName: "broken_tool",
+        args: {},
+      },
+    ]);
+  });
+
+  it("should handle empty content with tool calls", () => {
+    const message: Message = {
+      id: "1",
+      role: "assistant",
+      content: "",
+      tool_calls: [
+        {
+          id: "tool_1",
+          type: "function",
+          function: {
+            name: "silent_tool",
+            arguments: JSON.stringify({ silent: true }),
+          },
+        },
+      ],
+    };
+
+    const result = renderMessage(message);
+    expect(result).toEqual([
+      {
+        type: "tool-call",
+        toolCallId: "tool_1",
+        toolName: "silent_tool",
+        args: { silent: true },
+      },
+    ]);
+  });
+
+  it("should handle tool calls with empty arguments", () => {
+    const message: Message = {
+      id: "1",
+      role: "assistant",
+      content: "Running tool...",
+      tool_calls: [
+        {
+          id: "tool_1",
+          type: "function",
+          function: {
+            name: "no_args_tool",
+            arguments: "",
+          },
+        },
+      ],
+    };
+
+    const result = renderMessage(message);
+    expect(result).toEqual([
+      { type: "text", text: "Running tool..." },
+      {
+        type: "tool-call",
+        toolCallId: "tool_1",
+        toolName: "no_args_tool",
+        args: {},
+      },
+    ]);
+  });
+
+  it("should handle tool calls with null/undefined arguments", () => {
+    const message: Message = {
+      id: "1",
+      role: "assistant",
+      content: "Testing edge case",
+      tool_calls: [
+        {
+          id: "tool_1",
+          type: "function",
+          function: {
+            name: "edge_case_tool",
+            arguments: JSON.stringify(null),
+          },
+        },
+      ],
+    };
+
+    const result = renderMessage(message);
+    expect(result).toEqual([
+      { type: "text", text: "Testing edge case" },
+      {
+        type: "tool-call",
+        toolCallId: "tool_1",
+        toolName: "edge_case_tool",
+        args: null,
+      },
+    ]);
+  });
+
+  it("should handle very large tool call arguments", () => {
+    const largeData = {
+      data: Array(1000).fill("test").join(""),
+      nested: {
+        deep: {
+          structure: Array(100).fill({ key: "value" }),
+        },
+      },
+    };
+
+    const message: Message = {
+      id: "1",
+      role: "assistant",
+      content: "Processing large data",
+      tool_calls: [
+        {
+          id: "tool_1",
+          type: "function",
+          function: {
+            name: "process_data",
+            arguments: JSON.stringify(largeData),
+          },
+        },
+      ],
+    };
+
+    const result = renderMessage(message);
+    expect(result).toHaveLength(2);
+    expect(result[1]).toMatchObject({
+      type: "tool-call",
+      toolCallId: "tool_1",
+      toolName: "process_data",
+    });
+    const toolCallPart = result[1] as any;
+    expect(JSON.stringify(toolCallPart.args)).toBe(JSON.stringify(largeData));
+  });
+
+  it("should handle user messages without tool calls", () => {
+    const message: Message = {
+      id: "1",
+      role: "user",
+      content: "Can you help me?",
+    };
+
+    const result = renderMessage(message);
+    expect(result).toEqual([
+      { type: "text", text: "Can you help me?" },
+    ]);
+  });
+
+  it("should handle system messages without tool calls", () => {
+    const message: Message = {
+      id: "1",
+      role: "system",
+      content: "You are a helpful assistant.",
+    };
+
+    const result = renderMessage(message);
+    expect(result).toEqual([
+      { type: "text", text: "You are a helpful assistant." },
+    ]);
+  });
+
+  it("should handle tool messages (for completeness)", () => {
+    const message: Message = {
+      id: "1",
+      role: "tool",
+      content: JSON.stringify({ result: "success" }),
+      tool_call_id: "tool_1",
+    };
+
+    const result = renderMessage(message);
+    expect(result).toEqual([
+      { type: "text", text: JSON.stringify({ result: "success" }) },
+    ]);
+  });
+
+  it("should handle mixed content with text before and after tool calls", () => {
+    const message: Message = {
+      id: "1",
+      role: "assistant",
+      content: "Starting analysis...\n\nProcessing complete!",
+      tool_calls: [
+        {
+          id: "tool_1",
+          type: "function",
+          function: {
+            name: "analyze",
+            arguments: JSON.stringify({ data: "test" }),
+          },
+        },
+      ],
+    };
+
+    const result = renderMessage(message);
+    // Tool calls are appended after content
+    expect(result).toEqual([
+      { type: "text", text: "Starting analysis...\n\nProcessing complete!" },
+      {
+        type: "tool-call",
+        toolCallId: "tool_1",
+        toolName: "analyze",
+        args: { data: "test" },
+      },
+    ]);
+  });
+
+  it("should handle special characters in tool names", () => {
+    const message: Message = {
+      id: "1",
+      role: "assistant",
+      content: "Running special tool",
+      tool_calls: [
+        {
+          id: "tool_1",
+          type: "function",
+          function: {
+            name: "tool-with-dashes_and_underscores",
+            arguments: JSON.stringify({ test: true }),
+          },
+        },
+      ],
+    };
+
+    const result = renderMessage(message);
+    expect(result[1]).toMatchObject({
+      type: "tool-call",
+      toolName: "tool-with-dashes_and_underscores",
+    });
+  });
+
+  it("should handle Unicode in tool arguments", () => {
+    const message: Message = {
+      id: "1",
+      role: "assistant",
+      content: "Processing international data",
+      tool_calls: [
+        {
+          id: "tool_1",
+          type: "function",
+          function: {
+            name: "translate",
+            arguments: JSON.stringify({
+              text: "Hello 你好 مرحبا こんにちは 🌍",
+              emoji: "🎉🎊🎈",
+            }),
+          },
+        },
+      ],
+    };
+
+    const result = renderMessage(message);
+    expect(result[1]).toMatchObject({
+      type: "tool-call",
+      args: {
+        text: "Hello 你好 مرحبا こんにちは 🌍",
+        emoji: "🎉🎊🎈",
+      },
+    });
+  });
+});

--- a/packages/code/src/ChatInterface.tsx
+++ b/packages/code/src/ChatInterface.tsx
@@ -38,12 +38,18 @@ const ChatInterface: React.FC<{
     };
   }, [isStreaming, setIsStreaming]);
 
-  const [_input, setInput] = useDictation("");
+  const [_input, _setInput] = useDictation("");
 
   const [_editingMessageId, _setEditingMessageId] = useState<string | null>(
     null,
   );
   const [_editInput, _setEditInput] = useState("");
+
+  // State to hold initial prompt data
+  const [initialPrompt, setInitialPrompt] = useState<{
+    prompt: string;
+    images: ImageData[];
+  } | null>(null);
 
   // Removed unused reset functionality since AssistantUI manages its own state
 
@@ -73,21 +79,23 @@ const ChatInterface: React.FC<{
       if (maybeKey) {
         const storedData = sessionStorage.getItem(maybeKey);
         if (storedData) {
-          const { prompt, images } = JSON.parse(storedData) as {
-            prompt: string;
-            images: ImageData[];
-          };
-          sessionStorage.removeItem(maybeKey);
+          try {
+            const { prompt, images } = JSON.parse(storedData) as {
+              prompt: string;
+              images: ImageData[];
+            };
+            sessionStorage.removeItem(maybeKey);
 
-          codeSession.getSession().then((_currentSession) => { // Renamed from cSess
-            // TODO: Implement sending initial message with Assistant UI
-            // For now, we'll store it to be handled by the AssistantUIDrawer
-            console.log("Initial message:", { prompt, images });
-          });
+            // Store the initial prompt data to pass to AssistantUIDrawer
+            setInitialPrompt({ prompt, images });
+          } catch (error) {
+            console.error("Failed to parse stored prompt data:", error);
+            sessionStorage.removeItem(maybeKey);
+          }
         }
       }
     }
-  }, [isOpen, localCodeSpace, setInput, codeSession]); // Renamed from cSess, used localCodeSpace and added to deps
+  }, [localCodeSpace]); // Only depend on localCodeSpace
 
   // Removed unused memoized callbacks since AssistantUI manages its own state
 
@@ -99,6 +107,7 @@ const ChatInterface: React.FC<{
       onClose={onClose}
       isDarkMode={isDarkMode}
       cSess={codeSession}
+      initialPrompt={initialPrompt}
     />
   );
 });

--- a/packages/code/src/ChatInterface.tsx
+++ b/packages/code/src/ChatInterface.tsx
@@ -2,6 +2,7 @@ import { AssistantUIDrawer } from "@/components/app/assistant-ui-drawer";
 import { useDarkMode } from "@/hooks/use-dark-mode";
 import { useDictation } from "@/hooks/use-dictation";
 import { useLocalStorage } from "@/hooks/use-local-storage";
+import { toast } from "@/hooks/use-toast";
 import type { ICode } from "@/lib/interfaces";
 import type { ImageData } from "@/lib/interfaces";
 import React, { useEffect, useRef, useState } from "react";
@@ -91,6 +92,13 @@ const ChatInterface: React.FC<{
           } catch (error) {
             console.error("Failed to parse stored prompt data:", error);
             sessionStorage.removeItem(maybeKey);
+            
+            // Notify user about the corrupted data
+            toast({
+              title: "Failed to load saved prompt",
+              description: "The saved prompt data was corrupted and could not be loaded.",
+              variant: "destructive",
+            });
           }
         }
       }

--- a/packages/code/src/__tests__/ChatInterface.spec.tsx
+++ b/packages/code/src/__tests__/ChatInterface.spec.tsx
@@ -74,7 +74,7 @@ describe("ChatInterface", () => {
     );
 
     expect(AssistantUIDrawer).toHaveBeenCalled();
-    const callArgs = (AssistantUIDrawer as Mock).mock.calls[0][0];
+    const callArgs = (AssistantUIDrawer as Mock).mock.calls[0]?.[0];
     expect(callArgs.isOpen).toBe(true);
     expect(callArgs.isDarkMode).toBe(false);
     expect(callArgs.cSess).toBe(mockCodeSession);
@@ -87,6 +87,10 @@ describe("ChatInterface", () => {
       {
         src: "data:image/png;base64,test",
         imageName: "test.png",
+        url: "http://example.com/test.png",
+        mediaType: "image/png",
+        data: "test",
+        type: "image",
       },
     ];
 
@@ -126,7 +130,7 @@ describe("ChatInterface", () => {
 
     await waitFor(() => {
       const calls = (AssistantUIDrawer as Mock).mock.calls;
-      const lastCall = calls[calls.length - 1][0];
+      const lastCall = calls[calls.length - 1]?.[0];
       expect(lastCall.initialPrompt).toEqual({
         prompt: mockPrompt,
         images: mockImages,
@@ -165,7 +169,7 @@ describe("ChatInterface", () => {
     }).not.toThrow();
 
     // Should still render with null initial prompt
-    const callArgs = (AssistantUIDrawer as Mock).mock.calls[0][0];
+    const callArgs = (AssistantUIDrawer as Mock).mock.calls[0]?.[0];
     expect(callArgs.initialPrompt).toBe(null);
 
     consoleSpy.mockRestore();
@@ -181,7 +185,7 @@ describe("ChatInterface", () => {
       />
     );
 
-    const callArgs = (AssistantUIDrawer as Mock).mock.calls[0][0];
+    const callArgs = (AssistantUIDrawer as Mock).mock.calls[0]?.[0];
     expect(callArgs.initialPrompt).toBe(null);
   });
 
@@ -244,7 +248,7 @@ describe("ChatInterface", () => {
       />
     );
 
-    const callArgs = (AssistantUIDrawer as Mock).mock.calls[0][0];
+    const callArgs = (AssistantUIDrawer as Mock).mock.calls[0]?.[0];
     expect(callArgs.onClose).toBe(onCloseMock);
   });
 
@@ -284,7 +288,7 @@ describe("ChatInterface", () => {
 
     await waitFor(() => {
       const calls = (AssistantUIDrawer as Mock).mock.calls;
-      const lastCall = calls[calls.length - 1][0];
+      const lastCall = calls[calls.length - 1]?.[0];
       expect(lastCall.initialPrompt).toEqual({
         prompt: "",
         images: [],

--- a/packages/code/src/__tests__/ChatInterface.spec.tsx
+++ b/packages/code/src/__tests__/ChatInterface.spec.tsx
@@ -1,0 +1,294 @@
+import { ChatInterface } from "../ChatInterface";
+import { AssistantUIDrawer } from "@/components/app/assistant-ui-drawer";
+import { useDarkMode } from "@/hooks/use-dark-mode";
+import { useLocalStorage } from "@/hooks/use-local-storage";
+import { useScreenshot } from "../hooks/useScreenshot";
+import { useDictation } from "@/hooks/use-dictation";
+import type { ICode, ImageData } from "@/lib/interfaces";
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+// Mock dependencies
+vi.mock("@/hooks/use-dark-mode");
+vi.mock("@/hooks/use-local-storage");
+vi.mock("../hooks/useScreenshot");
+vi.mock("@/hooks/use-dictation");
+vi.mock("@/components/app/assistant-ui-drawer", () => ({
+  AssistantUIDrawer: vi.fn(() => null),
+}));
+
+// Mock ICode interface
+const mockCodeSession: ICode = {
+  getCodeSpace: vi.fn().mockReturnValue("test-space"),
+  getSession: vi.fn().mockResolvedValue({}),
+} as unknown as ICode;
+
+describe("ChatInterface", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+
+    // Setup default mocks
+    (useDarkMode as Mock).mockReturnValue({
+      isDarkMode: false,
+      toggleDarkMode: vi.fn(),
+    });
+
+    (useLocalStorage as Mock).mockReturnValue([false, vi.fn()]);
+
+    (useScreenshot as Mock).mockReturnValue({
+      isScreenshotLoading: false,
+      screenshotImage: null,
+      handleScreenshotClick: vi.fn(),
+      handleCancelScreenshot: vi.fn(),
+    });
+
+    (useDictation as Mock).mockReturnValue(["", vi.fn()]);
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+  });
+
+  it("should not render when isOpen is false", () => {
+    const { container } = render(
+      <ChatInterface
+        isOpen={false}
+        codeSession={mockCodeSession}
+        codeSpace="test-space"
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("should render AssistantUIDrawer when isOpen is true", () => {
+    render(
+      <ChatInterface
+        isOpen={true}
+        codeSession={mockCodeSession}
+        codeSpace="test-space"
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(AssistantUIDrawer).toHaveBeenCalled();
+    const callArgs = (AssistantUIDrawer as Mock).mock.calls[0][0];
+    expect(callArgs.isOpen).toBe(true);
+    expect(callArgs.isDarkMode).toBe(false);
+    expect(callArgs.cSess).toBe(mockCodeSession);
+    expect(callArgs.initialPrompt).toBe(null);
+  });
+
+  it("should pass initial prompt from sessionStorage when codeSpace contains a key", async () => {
+    const mockPrompt = "Create a todo app";
+    const mockImages: ImageData[] = [
+      {
+        src: "data:image/png;base64,test",
+        imageName: "test.png",
+      },
+    ];
+
+    const testKey = "abc123";
+    const codeSpaceWithKey = `x-${testKey}`;
+
+    // Store data in sessionStorage
+    sessionStorage.setItem(
+      testKey,
+      JSON.stringify({ prompt: mockPrompt, images: mockImages })
+    );
+
+    // Mock getCodeSpace to return our test code space
+    const mockCodeSessionWithKey = {
+      ...mockCodeSession,
+      getCodeSpace: vi.fn().mockReturnValue(codeSpaceWithKey),
+    };
+
+    const { rerender } = render(
+      <ChatInterface
+        isOpen={true}
+        codeSession={mockCodeSessionWithKey}
+        codeSpace={codeSpaceWithKey}
+        onClose={vi.fn()}
+      />
+    );
+
+    // Force re-render to trigger effect
+    rerender(
+      <ChatInterface
+        isOpen={true}
+        codeSession={mockCodeSessionWithKey}
+        codeSpace={codeSpaceWithKey}
+        onClose={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      const calls = (AssistantUIDrawer as Mock).mock.calls;
+      const lastCall = calls[calls.length - 1][0];
+      expect(lastCall.initialPrompt).toEqual({
+        prompt: mockPrompt,
+        images: mockImages,
+      });
+    });
+
+    // Verify sessionStorage was cleared
+    expect(sessionStorage.getItem(testKey)).toBeNull();
+  });
+
+  it("should handle invalid JSON in sessionStorage gracefully", () => {
+    const testKey = "invalid123";
+    const codeSpaceWithKey = `x-${testKey}`;
+
+    // Store invalid JSON
+    sessionStorage.setItem(testKey, "invalid json");
+
+    const mockCodeSessionWithKey = {
+      ...mockCodeSession,
+      getCodeSpace: vi.fn().mockReturnValue(codeSpaceWithKey),
+    };
+
+    // Spy on console.error to suppress error output
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // Should not throw when rendering
+    expect(() => {
+      render(
+        <ChatInterface
+          isOpen={true}
+          codeSession={mockCodeSessionWithKey}
+          codeSpace={codeSpaceWithKey}
+          onClose={vi.fn()}
+        />
+      );
+    }).not.toThrow();
+
+    // Should still render with null initial prompt
+    const callArgs = (AssistantUIDrawer as Mock).mock.calls[0][0];
+    expect(callArgs.initialPrompt).toBe(null);
+
+    consoleSpy.mockRestore();
+  });
+
+  it("should not set initial prompt when codeSpace does not contain a key", () => {
+    render(
+      <ChatInterface
+        isOpen={true}
+        codeSession={mockCodeSession}
+        codeSpace="regular-space"
+        onClose={vi.fn()}
+      />
+    );
+
+    const callArgs = (AssistantUIDrawer as Mock).mock.calls[0][0];
+    expect(callArgs.initialPrompt).toBe(null);
+  });
+
+  it("should handle streaming state timeout", async () => {
+    vi.useFakeTimers();
+    const setIsStreamingMock = vi.fn();
+    (useLocalStorage as Mock).mockReturnValue([true, setIsStreamingMock]);
+
+    render(
+      <ChatInterface
+        isOpen={true}
+        codeSession={mockCodeSession}
+        codeSpace="test-space"
+        onClose={vi.fn()}
+      />
+    );
+
+    // Fast-forward time by 5 seconds
+    vi.advanceTimersByTime(5000);
+
+    expect(setIsStreamingMock).toHaveBeenCalledWith(false);
+
+    vi.useRealTimers();
+  });
+
+  it("should scroll to bottom when opened", async () => {
+    const scrollIntoViewMock = vi.fn();
+    const getElementByIdMock = vi.fn().mockReturnValue({
+      scrollIntoView: scrollIntoViewMock,
+    });
+    document.getElementById = getElementByIdMock;
+
+    render(
+      <ChatInterface
+        isOpen={true}
+        codeSession={mockCodeSession}
+        codeSpace="test-space"
+        onClose={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(getElementByIdMock).toHaveBeenCalledWith("after-last-message");
+      expect(scrollIntoViewMock).toHaveBeenCalledWith({
+        behavior: "instant",
+        block: "end",
+      });
+    });
+  });
+
+  it("should pass through onClose callback", () => {
+    const onCloseMock = vi.fn();
+
+    render(
+      <ChatInterface
+        isOpen={true}
+        codeSession={mockCodeSession}
+        codeSpace="test-space"
+        onClose={onCloseMock}
+      />
+    );
+
+    const callArgs = (AssistantUIDrawer as Mock).mock.calls[0][0];
+    expect(callArgs.onClose).toBe(onCloseMock);
+  });
+
+  it("should handle empty prompt and images from sessionStorage", async () => {
+    const testKey = "empty123";
+    const codeSpaceWithKey = `x-${testKey}`;
+
+    // Store empty data
+    sessionStorage.setItem(
+      testKey,
+      JSON.stringify({ prompt: "", images: [] })
+    );
+
+    const mockCodeSessionWithKey = {
+      ...mockCodeSession,
+      getCodeSpace: vi.fn().mockReturnValue(codeSpaceWithKey),
+    };
+
+    const { rerender } = render(
+      <ChatInterface
+        isOpen={true}
+        codeSession={mockCodeSessionWithKey}
+        codeSpace={codeSpaceWithKey}
+        onClose={vi.fn()}
+      />
+    );
+
+    // Force re-render to trigger effect
+    rerender(
+      <ChatInterface
+        isOpen={true}
+        codeSession={mockCodeSessionWithKey}
+        codeSpace={codeSpaceWithKey}
+        onClose={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      const calls = (AssistantUIDrawer as Mock).mock.calls;
+      const lastCall = calls[calls.length - 1][0];
+      expect(lastCall.initialPrompt).toEqual({
+        prompt: "",
+        images: [],
+      });
+    });
+  });
+});

--- a/packages/code/src/__tests__/integration/start-with-prompt-flow.spec.tsx
+++ b/packages/code/src/__tests__/integration/start-with-prompt-flow.spec.tsx
@@ -14,9 +14,9 @@ vi.mock("@/lib/md5");
 vi.mock("@/lib/process-image");
 vi.mock("framer-motion", () => ({
   motion: {
-    img: ({ children, ...props }: any) => <img {...props}>{children}</img>,
+    img: ({ children, ...props }: { children?: React.ReactNode; [key: string]: unknown }) => <img {...props}>{children}</img>,
   },
-  AnimatePresence: ({ children }: any) => children,
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => children,
 }));
 
 // Mock location
@@ -56,7 +56,7 @@ describe("StartWithPrompt Integration Flow", () => {
       mediaType: "image/png",
       data: "processed",
       type: "image",
-    } as any);
+    } as unknown as ImageData);
   });
 
   afterEach(() => {

--- a/packages/code/src/__tests__/integration/start-with-prompt-flow.spec.tsx
+++ b/packages/code/src/__tests__/integration/start-with-prompt-flow.spec.tsx
@@ -1,0 +1,356 @@
+import { StartWithPrompt } from "@/components/ui/start-with-prompt";
+import { useDarkMode } from "@/hooks/use-dark-mode";
+import { useDictation } from "@/hooks/use-dictation";
+import type { ImageData } from "@/lib/interfaces";
+import { md5 } from "@/lib/md5";
+import { processImage } from "@/lib/process-image";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock dependencies
+vi.mock("@/hooks/use-dark-mode");
+vi.mock("@/hooks/use-dictation");
+vi.mock("@/lib/md5");
+vi.mock("@/lib/process-image");
+
+// Mock location
+const mockLocation = {
+  href: "",
+};
+Object.defineProperty(window, "location", {
+  value: mockLocation,
+  writable: true,
+});
+
+describe("StartWithPrompt Integration Flow", () => {
+  const mockSetPrompt = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    mockLocation.href = "";
+
+    // Setup default mocks
+    vi.mocked(useDarkMode).mockReturnValue({
+      isDarkMode: false,
+      toggleDarkMode: vi.fn(),
+    });
+
+    vi.mocked(useDictation).mockImplementation((initialValue) => [initialValue, mockSetPrompt]);
+    vi.mocked(md5).mockReturnValue("test-hash-123");
+    vi.mocked(processImage).mockResolvedValue({
+      src: "data:image/png;base64,processed",
+      imageName: "processed-image.png",
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("Complete User Flow", () => {
+    it("should handle the complete flow from prompt entry to navigation", async () => {
+      const user = userEvent.setup();
+      
+      render(<StartWithPrompt />);
+
+      // 1. User enters a prompt
+      const textarea = screen.getByPlaceholderText("Enter your prompt here or paste an image...");
+      await user.type(textarea, "Create a todo list application");
+
+      // Verify prompt was set
+      expect(mockSetPrompt).toHaveBeenLastCalledWith("Create a todo list application");
+
+      // 2. User clicks Generate
+      const generateButton = screen.getByRole("button", { name: /generate/i });
+      await user.click(generateButton);
+
+      // 3. Verify data was stored in sessionStorage
+      const storedData = sessionStorage.getItem("test-hash-123");
+      expect(storedData).toBeTruthy();
+      
+      const parsedData = JSON.parse(storedData!);
+      expect(parsedData).toEqual({
+        prompt: "Create a todo list application",
+        images: [],
+      });
+
+      // 4. Verify navigation happened
+      expect(mockLocation.href).toBe("/live/x-test-hash-123");
+    });
+
+    it("should handle prompt with images", async () => {
+      const user = userEvent.setup();
+      
+      render(<StartWithPrompt />);
+
+      // 1. User enters a prompt
+      const textarea = screen.getByPlaceholderText("Enter your prompt here or paste an image...");
+      await user.type(textarea, "Recreate this design");
+
+      // 2. User uploads an image
+      const file = new File(["dummy content"], "design.png", { type: "image/png" });
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+      
+      await waitFor(() => {
+        fireEvent.change(fileInput, { target: { files: [file] } });
+      });
+
+      // Wait for image processing
+      await waitFor(() => {
+        const uploadedImages = screen.getAllByAltText(/Uploaded/);
+        expect(uploadedImages).toHaveLength(1);
+      });
+
+      // 3. User clicks Generate
+      const generateButton = screen.getByRole("button", { name: /generate/i });
+      await user.click(generateButton);
+
+      // 4. Verify data was stored with images
+      const storedData = sessionStorage.getItem("test-hash-123");
+      const parsedData = JSON.parse(storedData!);
+      
+      expect(parsedData).toEqual({
+        prompt: "Recreate this design",
+        images: [{
+          src: "data:image/png;base64,processed",
+          imageName: "processed-image.png",
+        }],
+      });
+
+      expect(mockLocation.href).toBe("/live/x-test-hash-123");
+    });
+
+    it("should handle paste image functionality", async () => {
+      render(<StartWithPrompt />);
+
+      const textarea = screen.getByPlaceholderText("Enter your prompt here or paste an image...");
+      
+      // Create a paste event with an image
+      const file = new File(["image data"], "pasted.png", { type: "image/png" });
+      const clipboardData = {
+        items: [{
+          type: "image/png",
+          getAsFile: () => file,
+        }],
+      };
+
+      fireEvent.paste(textarea, { clipboardData });
+
+      // Wait for image processing
+      await waitFor(() => {
+        const uploadedImages = screen.getAllByAltText(/Uploaded/);
+        expect(uploadedImages).toHaveLength(1);
+      });
+
+      // Add prompt and generate
+      fireEvent.change(textarea, { target: { value: "Analyze this pasted image" } });
+      
+      const generateButton = screen.getByRole("button", { name: /generate/i });
+      fireEvent.click(generateButton);
+
+      const storedData = sessionStorage.getItem("test-hash-123");
+      const parsedData = JSON.parse(storedData!);
+      
+      expect(parsedData.images).toHaveLength(1);
+      expect(parsedData.prompt).toBe("Analyze this pasted image");
+    });
+
+    it("should handle drag and drop images", async () => {
+      render(<StartWithPrompt />);
+
+      const dropZone = screen.getByText("Generate a new app or website").closest("div");
+      const file = new File(["image data"], "dropped.png", { type: "image/png" });
+
+      // Simulate drag over
+      fireEvent.dragOver(dropZone!, {
+        dataTransfer: { files: [] },
+      });
+
+      // Simulate drop
+      fireEvent.drop(dropZone!, {
+        dataTransfer: { files: [file] },
+      });
+
+      // Wait for image processing
+      await waitFor(() => {
+        const uploadedImages = screen.getAllByAltText(/Uploaded/);
+        expect(uploadedImages).toHaveLength(1);
+      });
+    });
+
+    it("should limit to 5 images maximum", async () => {
+      render(<StartWithPrompt />);
+
+      // Upload 5 images
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+      
+      for (let i = 0; i < 5; i++) {
+        const file = new File(["content"], `image${i}.png`, { type: "image/png" });
+        fireEvent.change(fileInput, { target: { files: [file] } });
+        
+        await waitFor(() => {
+          const uploadedImages = screen.getAllByAltText(/Uploaded/);
+          expect(uploadedImages).toHaveLength(i + 1);
+        });
+      }
+
+      // Upload button should be disabled
+      const uploadButton = screen.getByRole("button", { name: /upload image/i });
+      expect(uploadButton).toHaveAttribute("aria-disabled", "true");
+
+      // Try to upload another image via paste - should not work
+      const textarea = screen.getByPlaceholderText("Enter your prompt here or paste an image...");
+      const file = new File(["data"], "extra.png", { type: "image/png" });
+      const clipboardData = {
+        items: [{
+          type: "image/png",
+          getAsFile: () => file,
+        }],
+      };
+
+      fireEvent.paste(textarea, { clipboardData });
+
+      // Should still have only 5 images
+      await waitFor(() => {
+        const uploadedImages = screen.getAllByAltText(/Uploaded/);
+        expect(uploadedImages).toHaveLength(5);
+      });
+    });
+
+    it("should handle image removal", async () => {
+      const user = userEvent.setup();
+      
+      render(<StartWithPrompt />);
+
+      // Upload an image
+      const file = new File(["content"], "test.png", { type: "image/png" });
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+      
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      await waitFor(() => {
+        expect(screen.getByAltText("Uploaded 0")).toBeInTheDocument();
+      });
+
+      // Remove the image
+      const removeButton = screen.getByLabelText("Remove image");
+      await user.click(removeButton);
+
+      // Image should be removed
+      await waitFor(() => {
+        expect(screen.queryByAltText("Uploaded 0")).not.toBeInTheDocument();
+      });
+
+      // Template button should reappear
+      expect(screen.getByText("Choose from templates")).toBeInTheDocument();
+    });
+
+    it("should generate unique hash for different prompts", async () => {
+      const { rerender } = render(<StartWithPrompt />);
+
+      // First prompt
+      vi.mocked(md5).mockReturnValueOnce("hash-1");
+      const textarea = screen.getByPlaceholderText("Enter your prompt here or paste an image...");
+      fireEvent.change(textarea, { target: { value: "First prompt" } });
+      fireEvent.click(screen.getByRole("button", { name: /generate/i }));
+
+      expect(mockLocation.href).toBe("/live/x-hash-1");
+      expect(sessionStorage.getItem("hash-1")).toBeTruthy();
+
+      // Reset for second prompt
+      mockLocation.href = "";
+      rerender(<StartWithPrompt />);
+
+      // Second prompt
+      vi.mocked(md5).mockReturnValueOnce("hash-2");
+      fireEvent.change(
+        screen.getByPlaceholderText("Enter your prompt here or paste an image..."),
+        { target: { value: "Second prompt" } }
+      );
+      fireEvent.click(screen.getByRole("button", { name: /generate/i }));
+
+      expect(mockLocation.href).toBe("/live/x-hash-2");
+      expect(sessionStorage.getItem("hash-2")).toBeTruthy();
+    });
+
+    it("should handle empty prompt generation", () => {
+      render(<StartWithPrompt />);
+
+      const generateButton = screen.getByRole("button", { name: /generate/i });
+      fireEvent.click(generateButton);
+
+      // Should still navigate with empty prompt
+      const storedData = sessionStorage.getItem("test-hash-123");
+      const parsedData = JSON.parse(storedData!);
+      
+      expect(parsedData).toEqual({
+        prompt: "",
+        images: [],
+      });
+
+      expect(mockLocation.href).toBe("/live/x-test-hash-123");
+    });
+
+    it("should navigate to templates when template button is clicked", async () => {
+      const user = userEvent.setup();
+      
+      render(<StartWithPrompt />);
+
+      const templateButton = screen.getByRole("button", { name: /choose from templates/i });
+      await user.click(templateButton);
+
+      expect(mockLocation.href).toBe("/start");
+    });
+
+    it("should handle image processing errors gracefully", async () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      vi.mocked(processImage).mockRejectedValueOnce(new Error("Processing failed"));
+
+      render(<StartWithPrompt />);
+
+      const file = new File(["content"], "error.png", { type: "image/png" });
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+      
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      await waitFor(() => {
+        expect(consoleSpy).toHaveBeenCalledWith(
+          "Error processing image:",
+          expect.any(Error)
+        );
+      });
+
+      // No image should be displayed
+      expect(screen.queryByAltText(/Uploaded/)).not.toBeInTheDocument();
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("Dark Mode Integration", () => {
+    it("should apply dark mode styles throughout the flow", () => {
+      vi.mocked(useDarkMode).mockReturnValue({
+        isDarkMode: true,
+        toggleDarkMode: vi.fn(),
+      });
+
+      render(<StartWithPrompt />);
+
+      // Check dark mode classes
+      const container = screen.getByText("Generate a new app or website").closest("div");
+      expect(container?.className).toContain("bg-gradient-to-br from-gray-900 to-gray-800");
+      expect(container?.className).toContain("text-white");
+
+      // Check textarea dark mode
+      const textarea = screen.getByPlaceholderText("Enter your prompt here or paste an image...");
+      expect(textarea.className).toContain("bg-gray-800");
+      expect(textarea.className).toContain("text-white");
+
+      // Check button dark mode
+      const generateButton = screen.getByRole("button", { name: /generate/i });
+      expect(generateButton.className).toContain("bg-purple-600");
+    });
+  });
+});

--- a/packages/code/src/__tests__/integration/start-with-prompt-flow.spec.tsx
+++ b/packages/code/src/__tests__/integration/start-with-prompt-flow.spec.tsx
@@ -1,6 +1,7 @@
 import { StartWithPrompt } from "@/components/ui/start-with-prompt";
 import { useDarkMode } from "@/hooks/use-dark-mode";
 import { useDictation } from "@/hooks/use-dictation";
+import type { ImageData } from "@/lib/interfaces";
 import { md5 } from "@/lib/md5";
 import { processImage } from "@/lib/process-image";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";

--- a/packages/js.spike.land/package.json
+++ b/packages/js.spike.land/package.json
@@ -22,7 +22,7 @@
     "@cloudflare/kv-asset-handler": "0.4.0",
     "rimraf": "6.0.1",
     "typescript": "5.8.3",
-    "wrangler": "4.26.1"
+    "wrangler": "4.27.0"
   },
   "dependencies": {
     "@spike-npm-land/code": "0.9.56",

--- a/packages/spike-land-renderer/package.json
+++ b/packages/spike-land-renderer/package.json
@@ -18,7 +18,7 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
-    "@cloudflare/vitest-pool-workers": "0.8.58",
+    "@cloudflare/vitest-pool-workers": "0.8.59",
     "@cloudflare/workers-types": "4.20250731.0",
     "@types/node": "24.1.0",
     "@vitest/runner": "3.2.4",
@@ -26,7 +26,7 @@
     "rimraf": "6.0.1",
     "typescript": "5.8.3",
     "vitest": "3.2.4",
-    "wrangler": "4.26.1"
+    "wrangler": "4.27.0"
   },
   "dependencies": {
     "@cloudflare/puppeteer": "1.0.4"

--- a/packages/spike.land/package.json
+++ b/packages/spike.land/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@cloudflare/kv-asset-handler": "0.4.0",
-    "@cloudflare/vitest-pool-workers": "0.8.58",
+    "@cloudflare/vitest-pool-workers": "0.8.59",
     "@cloudflare/workers-types": "4.20250731.0",
     "@eslint/js": "9.32.0",
     "@rollup/plugin-commonjs": "28.0.6",
@@ -67,7 +67,7 @@
     "jiti": "2.5.1",
     "mime-db": "1.54.0",
     "mime-types": "3.0.1",
-    "miniflare": "4.20250726.0",
+    "miniflare": "4.20250730.0",
     "openai": "5.11.0",
     "openai-edge": "1.2.3",
     "p-map": "7.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -721,56 +721,56 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cloudflare/vitest-pool-workers@npm:0.8.58":
-  version: 0.8.58
-  resolution: "@cloudflare/vitest-pool-workers@npm:0.8.58"
+"@cloudflare/vitest-pool-workers@npm:0.8.59":
+  version: 0.8.59
+  resolution: "@cloudflare/vitest-pool-workers@npm:0.8.59"
   dependencies:
     birpc: "npm:0.2.14"
     cjs-module-lexer: "npm:^1.2.3"
     devalue: "npm:^4.3.0"
-    miniflare: "npm:4.20250726.0"
+    miniflare: "npm:4.20250730.0"
     semver: "npm:^7.7.1"
-    wrangler: "npm:4.26.1"
+    wrangler: "npm:4.27.0"
     zod: "npm:^3.22.3"
   peerDependencies:
     "@vitest/runner": 2.0.x - 3.2.x
     "@vitest/snapshot": 2.0.x - 3.2.x
     vitest: 2.0.x - 3.2.x
-  checksum: 10c0/cf34e856984f537888b8ef7d2505cbfe14eb5a60d885e53ae910598fa1768dcb7c12f53ef674589088e6a853263fb3366578da3e17b077dfce2538f7ea11a630
+  checksum: 10c0/908d106a2cec2099b73ad3cbadfbc439647f62d5e32a82642499713eba93e08159732878f399c1eaf0e185b0ab1159e0f385507a717c07e608d5aa56c7a21920
   languageName: node
   linkType: hard
 
-"@cloudflare/workerd-darwin-64@npm:1.20250726.0":
-  version: 1.20250726.0
-  resolution: "@cloudflare/workerd-darwin-64@npm:1.20250726.0"
+"@cloudflare/workerd-darwin-64@npm:1.20250730.0":
+  version: 1.20250730.0
+  resolution: "@cloudflare/workerd-darwin-64@npm:1.20250730.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@cloudflare/workerd-darwin-arm64@npm:1.20250726.0":
-  version: 1.20250726.0
-  resolution: "@cloudflare/workerd-darwin-arm64@npm:1.20250726.0"
+"@cloudflare/workerd-darwin-arm64@npm:1.20250730.0":
+  version: 1.20250730.0
+  resolution: "@cloudflare/workerd-darwin-arm64@npm:1.20250730.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@cloudflare/workerd-linux-64@npm:1.20250726.0":
-  version: 1.20250726.0
-  resolution: "@cloudflare/workerd-linux-64@npm:1.20250726.0"
+"@cloudflare/workerd-linux-64@npm:1.20250730.0":
+  version: 1.20250730.0
+  resolution: "@cloudflare/workerd-linux-64@npm:1.20250730.0"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@cloudflare/workerd-linux-arm64@npm:1.20250726.0":
-  version: 1.20250726.0
-  resolution: "@cloudflare/workerd-linux-arm64@npm:1.20250726.0"
+"@cloudflare/workerd-linux-arm64@npm:1.20250730.0":
+  version: 1.20250730.0
+  resolution: "@cloudflare/workerd-linux-arm64@npm:1.20250730.0"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@cloudflare/workerd-windows-64@npm:1.20250726.0":
-  version: 1.20250726.0
-  resolution: "@cloudflare/workerd-windows-64@npm:1.20250726.0"
+"@cloudflare/workerd-windows-64@npm:1.20250730.0":
+  version: 1.20250730.0
+  resolution: "@cloudflare/workerd-windows-64@npm:1.20250730.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -3898,7 +3898,7 @@ __metadata:
     jsdom: "npm:26.1.0"
     jsondiffpatch: "npm:0.7.3"
     lightningcss: "npm:^1.30.1"
-    lucide-react: "npm:0.534.0"
+    lucide-react: "npm:0.535.0"
     mime-types: "npm:3.0.1"
     module: "npm:1.2.5"
     monaco-editor: "npm:0.52.2"
@@ -4021,7 +4021,7 @@ __metadata:
   resolution: "@spike-npm-land/renderer@workspace:packages/spike-land-renderer"
   dependencies:
     "@cloudflare/puppeteer": "npm:1.0.4"
-    "@cloudflare/vitest-pool-workers": "npm:0.8.58"
+    "@cloudflare/vitest-pool-workers": "npm:0.8.59"
     "@cloudflare/workers-types": "npm:4.20250731.0"
     "@types/node": "npm:24.1.0"
     "@vitest/runner": "npm:3.2.4"
@@ -4029,7 +4029,7 @@ __metadata:
     rimraf: "npm:6.0.1"
     typescript: "npm:5.8.3"
     vitest: "npm:3.2.4"
-    wrangler: "npm:4.26.1"
+    wrangler: "npm:4.27.0"
   languageName: unknown
   linkType: soft
 
@@ -4050,7 +4050,7 @@ __metadata:
     "@clerk/backend": "npm:2.6.1"
     "@clerk/clerk-sdk-node": "npm:5.1.6"
     "@cloudflare/kv-asset-handler": "npm:0.4.0"
-    "@cloudflare/vitest-pool-workers": "npm:0.8.58"
+    "@cloudflare/vitest-pool-workers": "npm:0.8.59"
     "@cloudflare/workers-types": "npm:4.20250731.0"
     "@eslint/js": "npm:9.32.0"
     "@rollup/plugin-commonjs": "npm:28.0.6"
@@ -4079,7 +4079,7 @@ __metadata:
     jiti: "npm:2.5.1"
     mime-db: "npm:1.54.0"
     mime-types: "npm:3.0.1"
-    miniflare: "npm:4.20250726.0"
+    miniflare: "npm:4.20250730.0"
     openai: "npm:5.11.0"
     openai-edge: "npm:1.2.3"
     p-map: "npm:7.0.3"
@@ -4107,7 +4107,7 @@ __metadata:
     esbuild-wasm: "npm:0.25.8"
     rimraf: "npm:6.0.1"
     typescript: "npm:5.8.3"
-    wrangler: "npm:4.26.1"
+    wrangler: "npm:4.27.0"
   languageName: unknown
   linkType: soft
 
@@ -10062,12 +10062,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lucide-react@npm:0.534.0":
-  version: 0.534.0
-  resolution: "lucide-react@npm:0.534.0"
+"lucide-react@npm:0.535.0":
+  version: 0.535.0
+  resolution: "lucide-react@npm:0.535.0"
   peerDependencies:
     react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10c0/83abbdf3e0661bffe2472577dbbea51afd83660870dbc02ed8a4d28269301c72f3ef8743373ddfcd6fcb736842d33d0851df45a55957b6ba1bae5cd84c77cac4
+  checksum: 10c0/688439e202b36866ee40479b9f1093a144cc249690c2710b463cdd6c5b00006b439d763840d8d1f4cfe91d51e036c30024ccff5290cd7842dd20ebe5c9e4a8b2
   languageName: node
   linkType: hard
 
@@ -10782,9 +10782,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"miniflare@npm:4.20250726.0":
-  version: 4.20250726.0
-  resolution: "miniflare@npm:4.20250726.0"
+"miniflare@npm:4.20250730.0":
+  version: 4.20250730.0
+  resolution: "miniflare@npm:4.20250730.0"
   dependencies:
     "@cspotcode/source-map-support": "npm:0.8.1"
     acorn: "npm:8.14.0"
@@ -10794,13 +10794,13 @@ __metadata:
     sharp: "npm:^0.33.5"
     stoppable: "npm:1.1.0"
     undici: "npm:^7.10.0"
-    workerd: "npm:1.20250726.0"
+    workerd: "npm:1.20250730.0"
     ws: "npm:8.18.0"
     youch: "npm:4.1.0-beta.10"
     zod: "npm:3.22.3"
   bin:
     miniflare: bootstrap.js
-  checksum: 10c0/e1712a172598943d419e70dfdbef4f5192b3f17166fda0eb6656d72850105484d96c3ca4e9550352fb5176900d26f22b809e3391e6415cdc8d52a5f5f6bef5f3
+  checksum: 10c0/f7df02dcd5d9c731ebee21ae189eba5688d8fb89435be791caf5f20673d6ae2af55028c2624ddc53c35de8416f6f8c4d8573d0512d0273d736a11af03ed47cc1
   languageName: node
   linkType: hard
 
@@ -15209,15 +15209,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"workerd@npm:1.20250726.0":
-  version: 1.20250726.0
-  resolution: "workerd@npm:1.20250726.0"
+"workerd@npm:1.20250730.0":
+  version: 1.20250730.0
+  resolution: "workerd@npm:1.20250730.0"
   dependencies:
-    "@cloudflare/workerd-darwin-64": "npm:1.20250726.0"
-    "@cloudflare/workerd-darwin-arm64": "npm:1.20250726.0"
-    "@cloudflare/workerd-linux-64": "npm:1.20250726.0"
-    "@cloudflare/workerd-linux-arm64": "npm:1.20250726.0"
-    "@cloudflare/workerd-windows-64": "npm:1.20250726.0"
+    "@cloudflare/workerd-darwin-64": "npm:1.20250730.0"
+    "@cloudflare/workerd-darwin-arm64": "npm:1.20250730.0"
+    "@cloudflare/workerd-linux-64": "npm:1.20250730.0"
+    "@cloudflare/workerd-linux-arm64": "npm:1.20250730.0"
+    "@cloudflare/workerd-windows-64": "npm:1.20250730.0"
   dependenciesMeta:
     "@cloudflare/workerd-darwin-64":
       optional: true
@@ -15231,25 +15231,25 @@ __metadata:
       optional: true
   bin:
     workerd: bin/workerd
-  checksum: 10c0/42ee6aa4bf622efa0a24c726176497bc613880e6754503e128072820eb7386965fde6c612c6674517a56e1c3ef777b9f2214100148465ce982d7f23163d9bf0d
+  checksum: 10c0/cd89d802a4bdb5ca1fea3cd84883179e9ebbbeb8aadc5744aa8dceebb4f2196438da57da69d92207aae453307381a696df654ee81926834de19f1e103df1ad72
   languageName: node
   linkType: hard
 
-"wrangler@npm:4.26.1":
-  version: 4.26.1
-  resolution: "wrangler@npm:4.26.1"
+"wrangler@npm:4.27.0":
+  version: 4.27.0
+  resolution: "wrangler@npm:4.27.0"
   dependencies:
     "@cloudflare/kv-asset-handler": "npm:0.4.0"
     "@cloudflare/unenv-preset": "npm:2.5.0"
     blake3-wasm: "npm:2.1.5"
     esbuild: "npm:0.25.4"
     fsevents: "npm:~2.3.2"
-    miniflare: "npm:4.20250726.0"
+    miniflare: "npm:4.20250730.0"
     path-to-regexp: "npm:6.3.0"
     unenv: "npm:2.0.0-rc.19"
-    workerd: "npm:1.20250726.0"
+    workerd: "npm:1.20250730.0"
   peerDependencies:
-    "@cloudflare/workers-types": ^4.20250726.0
+    "@cloudflare/workers-types": ^4.20250730.0
   dependenciesMeta:
     fsevents:
       optional: true
@@ -15259,7 +15259,7 @@ __metadata:
   bin:
     wrangler: bin/wrangler.js
     wrangler2: bin/wrangler.js
-  checksum: 10c0/a888d939c9b819cde70aeda28cd0a85a8ccfa549938136e78eb3f67eb2f3b360e9c64dc95ad1c88169f08e9bbc76f111b55ddcfa958ea0ea605ebc21121e0d71
+  checksum: 10c0/ef2d3218e2a9a76574cddad8a4551023fa792f69b8028b3a5eac34182a94f20318d596526f5877c3d36d21f8c2c34c3c176f44f84f2508edbbf422c6d3373cc7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### **PR Type**
Enhancement

___

### **Description**
- Integrate start-with-prompt to auto-send first message in chat
- Add comprehensive unit tests for chat components (50+ tests)
- Implement error handling for corrupted sessionStorage data
- Add toast notifications for better user experience
- **NEW: Implement tool call visibility in chat UI**
  - Show tool calls with expandable details
  - Display parameters and results
  - Group consecutive tool calls

___

### **New Features Added**

#### Tool Call Visibility
- Added `ToolCall` component to display individual tool calls with:
  - Tool name with wrench icon
  - Expandable/collapsible UI
  - Parameter display in formatted JSON
  - Result display when available
  - Loading state while executing
  
- Added `ToolCallGroup` component to group consecutive tool calls

- Updated `Thread` component to render tool calls in messages

- Added comprehensive test coverage:
  - Unit tests for ToolCall and ToolCallGroup components
  - Integration tests for message handling with tool calls
  - Edge case testing for error scenarios
  - 100+ new tests added

___

### Diagram Walkthrough

```mermaid
flowchart LR
  A["StartWithPrompt"] -- "stores prompt/images" --> B["sessionStorage"]
  B -- "navigates to" --> C["/live/x-{key}"]
  C -- "opens" --> D["ChatInterface"]
  D -- "passes initialPrompt" --> E["AssistantUIDrawer"]
  E -- "forwards to" --> F["AssistantUIChat"]
  F -- "auto-sends via" --> G["AutoSendInitialPrompt"]
  G -- "uses" --> H["useThreadRuntime"]
  
  I["AI Response"] -- "contains tool calls" --> J["MessagePrimitive.Parts"]
  J -- "renders with" --> K["ToolCall Component"]
  K -- "displays" --> L["Tool Name, Args, Results"]
```

### Test Plan
- [x] Run `yarn test` - all tests pass (387 passing)
- [x] Run `yarn types:check` - no TypeScript errors
- [x] Run `yarn eslint` - only acceptable warnings in test files
- [x] Manual testing of initial prompt functionality
- [x] Manual testing of tool call display
- [ ] Review UI/UX of new components
- [ ] Test with real AI tool calls in production

🤖 Generated with [Claude Code](https://claude.ai/code)